### PR TITLE
SP-1a: managed bridge for native→managed pinned thunks (Tasks 3 & 5)

### DIFF
--- a/Assets/Scripts/O3DE.Core.Tests/Interop/ScriptComponentBridgeTests.cs
+++ b/Assets/Scripts/O3DE.Core.Tests/Interop/ScriptComponentBridgeTests.cs
@@ -6,6 +6,8 @@
 //
 
 using System;
+using System.Collections.Generic;
+using O3DE;
 using O3DE.Interop;
 
 namespace O3DE.Core.Tests.Interop;
@@ -93,4 +95,80 @@ public class ScriptComponentBridgeTests
         var act = () => ScriptComponentBridge.Unregister(handle);
         act.Should().NotThrow();
     }
+}
+
+/// <summary>
+/// Pins the native ABI. LifecycleId values are passed as raw integers from
+/// CSharpScriptComponent.cpp's enum of the same name; if these drift apart,
+/// Tick starts calling OnDestroy and nothing fails to compile on either side.
+/// </summary>
+public class LifecycleIdAbiTests
+{
+    [Theory]
+    [InlineData(LifecycleId.OnCreate, 1)]
+    [InlineData(LifecycleId.OnDestroy, 2)]
+    [InlineData(LifecycleId.Tick, 3)]
+    [InlineData(LifecycleId.OnTransformChanged, 4)]
+    public void LifecycleId_HasStableNativeValue(LifecycleId id, int expected)
+    {
+        ((int)id).Should().Be(expected,
+            "these integers are the native ABI - renumbering silently misroutes callbacks");
+    }
+
+    [Fact]
+    public void Dispatch_UnknownLifecycleId_ReturnsFalse()
+    {
+        var component = new DispatchProbe();
+        ScriptComponentBridge.Dispatch(component, (LifecycleId)9999, 0f).Should().BeFalse();
+        component.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Dispatch_NonScriptComponent_ReturnsFalse()
+    {
+        ScriptComponentBridge.Dispatch(new object(), LifecycleId.Tick, 0f).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Dispatch_RoutesTickWithDeltaTime()
+    {
+        var component = new DispatchProbe();
+
+        ScriptComponentBridge.Dispatch(component, LifecycleId.Tick, 0.25f).Should().BeTrue();
+
+        component.Calls.Should().ContainSingle().Which.Should().Be("Tick:0.25");
+    }
+
+    [Theory]
+    [InlineData(LifecycleId.OnCreate, "OnCreate")]
+    [InlineData(LifecycleId.OnDestroy, "OnDestroy")]
+    [InlineData(LifecycleId.OnTransformChanged, "OnTransformChanged")]
+    public void Dispatch_RoutesEachLifecycleToItsCallback(LifecycleId id, string expected)
+    {
+        var component = new DispatchProbe();
+
+        ScriptComponentBridge.Dispatch(component, id, 0f).Should().BeTrue();
+
+        component.Calls.Should().ContainSingle().Which.Should().Be(expected);
+    }
+}
+
+/// <summary>
+/// Records which callbacks fired, so routing can be asserted.
+///
+/// NOTE: overrides OnUpdate, NOT Tick. In ScriptComponent, `Tick(float)` is a
+/// public NON-virtual method (the native entry point, which also drives the
+/// Invoke/InvokeRepeating timer machinery) and it calls the virtual
+/// `OnUpdate(float)`. Attempting `override void Tick` does not compile.
+/// Dispatching LifecycleId.Tick therefore surfaces here as an OnUpdate call.
+/// </summary>
+internal sealed class DispatchProbe : ScriptComponent
+{
+    public List<string> Calls { get; } = new List<string>();
+
+    public override void OnCreate() => Calls.Add("OnCreate");
+    public override void OnDestroy() => Calls.Add("OnDestroy");
+    public override void OnUpdate(float deltaTime) =>
+        Calls.Add($"Tick:{deltaTime.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+    public override void OnTransformChanged() => Calls.Add("OnTransformChanged");
 }

--- a/Assets/Scripts/O3DE.Core.Tests/Interop/ScriptComponentBridgeTests.cs
+++ b/Assets/Scripts/O3DE.Core.Tests/Interop/ScriptComponentBridgeTests.cs
@@ -1,0 +1,96 @@
+//
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// For complete copyright and license terms please see the LICENSE at the root of this distribution.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+using System;
+using O3DE.Interop;
+
+namespace O3DE.Core.Tests.Interop;
+
+/// <summary>
+/// The handle table is what makes a STATIC [UnmanagedCallersOnly] thunk able to
+/// service INSTANCE lifecycle callbacks: C++ holds an opaque int per component
+/// and hands it back on every call. These pin the properties the native side
+/// relies on - handles are never 0 (0 is the native "no handle" sentinel),
+/// they are not reused while live, and resolving a stale handle is safe.
+/// </summary>
+public class ScriptComponentBridgeTests
+{
+    [Fact]
+    public void Register_ReturnsNonZeroHandle()
+    {
+        var handle = ScriptComponentBridge.Register(new object());
+        try
+        {
+            handle.Should().NotBe(0, "0 is the native sentinel for 'no handle'");
+        }
+        finally
+        {
+            ScriptComponentBridge.Unregister(handle);
+        }
+    }
+
+    [Fact]
+    public void Resolve_ReturnsTheRegisteredInstance()
+    {
+        var instance = new object();
+        var handle = ScriptComponentBridge.Register(instance);
+        try
+        {
+            ScriptComponentBridge.Resolve(handle).Should().BeSameAs(instance);
+        }
+        finally
+        {
+            ScriptComponentBridge.Unregister(handle);
+        }
+    }
+
+    [Fact]
+    public void DistinctInstances_GetDistinctHandles()
+    {
+        var a = ScriptComponentBridge.Register(new object());
+        var b = ScriptComponentBridge.Register(new object());
+        try
+        {
+            a.Should().NotBe(b);
+        }
+        finally
+        {
+            ScriptComponentBridge.Unregister(a);
+            ScriptComponentBridge.Unregister(b);
+        }
+    }
+
+    [Fact]
+    public void Resolve_AfterUnregister_ReturnsNull()
+    {
+        var handle = ScriptComponentBridge.Register(new object());
+        ScriptComponentBridge.Unregister(handle);
+
+        // Native code can legitimately race a teardown against an in-flight
+        // tick; resolving a dead handle must be safe, not throw.
+        ScriptComponentBridge.Resolve(handle).Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_UnknownHandle_ReturnsNull()
+    {
+        ScriptComponentBridge.Resolve(0).Should().BeNull();
+        ScriptComponentBridge.Resolve(999999).Should().BeNull();
+        ScriptComponentBridge.Resolve(-1).Should().BeNull();
+    }
+
+    [Fact]
+    public void Unregister_IsIdempotent()
+    {
+        var handle = ScriptComponentBridge.Register(new object());
+        ScriptComponentBridge.Unregister(handle);
+
+        // Double-unregister must not throw - teardown paths can run twice.
+        var act = () => ScriptComponentBridge.Unregister(handle);
+        act.Should().NotThrow();
+    }
+}

--- a/Assets/Scripts/O3DE.Core.Tests/O3DE.Core.Tests.csproj
+++ b/Assets/Scripts/O3DE.Core.Tests/O3DE.Core.Tests.csproj
@@ -41,6 +41,9 @@
     <Compile Include="..\O3DE.Core\Debug.cs" Link="O3DE.Core\Debug.cs" />
     <Compile Include="..\O3DE.Core\Reflection\NativeReflection.cs" Link="O3DE.Core\Reflection\NativeReflection.cs" />
     <Compile Include="..\O3DE.Core\Entity.cs" Link="O3DE.Core\Entity.cs" />
+    <Compile Include="..\O3DE.Core\ExposedProperty.cs" Link="O3DE.Core\ExposedProperty.cs" />
+    <Compile Include="..\O3DE.Core\ScriptComponent.cs" Link="O3DE.Core\ScriptComponent.cs" />
+    <Compile Include="..\O3DE.Core\Interop\ScriptComponentBridge.cs" Link="O3DE.Core\Interop\ScriptComponentBridge.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Assets/Scripts/O3DE.Core.Tests/Stubs/TransformStub.cs
+++ b/Assets/Scripts/O3DE.Core.Tests/Stubs/TransformStub.cs
@@ -7,8 +7,10 @@ namespace O3DE
     /// calls) can compile in this test project. The real Transform.cs pulls in
     /// a dozen more InternalCalls.Transform_* delegate* fields plus Quaternion
     /// math not needed here - no test in this project exercises Transform
-    /// behavior, only Entity.GetChildren() (see EntityGetChildrenTests.cs), so
-    /// this stub only needs to satisfy the compile-time constructor call.
+    /// behavior, only Entity.GetChildren() (see EntityGetChildrenTests.cs) and
+    /// ScriptComponent's lazily-initialized Transform property (see
+    /// Interop/ScriptComponentBridgeTests.cs), so this stub only needs to
+    /// satisfy the compile-time constructor calls.
     /// </summary>
     public class Transform
     {
@@ -17,6 +19,15 @@ namespace O3DE
         internal Transform(Entity entity)
         {
             m_entity = entity;
+        }
+
+        /// <summary>
+        /// Matches the real Transform's `public Transform(ulong entityId)`,
+        /// used by ScriptComponent.cs's `Transform` property.
+        /// </summary>
+        public Transform(ulong entityId)
+        {
+            m_entity = new Entity(entityId);
         }
 
         public Entity Entity => m_entity;

--- a/Assets/Scripts/O3DE.Core/Interop/ScriptComponentBridge.cs
+++ b/Assets/Scripts/O3DE.Core/Interop/ScriptComponentBridge.cs
@@ -1,0 +1,147 @@
+//
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// For complete copyright and license terms please see the LICENSE at the root of this distribution.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace O3DE.Interop
+{
+    /// <summary>
+    /// Which lifecycle callback a native Invoke is requesting. Values are part
+    /// of the native ABI - C++ passes these integers - so they must never be
+    /// renumbered without changing CSharpScriptComponent.cpp in lockstep.
+    /// </summary>
+    public enum LifecycleId
+    {
+        OnCreate = 1,
+        OnDestroy = 2,
+        Tick = 3,
+        OnTransformChanged = 4,
+    }
+
+    /// <summary>
+    /// The native-callable entry point for script component lifecycle calls.
+    ///
+    /// Coral's ManagedObject.InvokeMethod does a managed-side string lookup plus
+    /// reflection dispatch on every call, which for Tick means every frame per
+    /// component. This bridge is resolved once to a raw function pointer via
+    /// Coral's GetFunctionPointer, after which calls cost an indirect call plus
+    /// an array index.
+    ///
+    /// The thunk target must be static, but lifecycle callbacks are per
+    /// instance, so C++ holds an opaque int handle per component and passes it
+    /// back on every call. Handle 0 is reserved as the native "no handle"
+    /// sentinel and is never issued.
+    /// </summary>
+    public static class ScriptComponentBridge
+    {
+        private static readonly object s_lock = new object();
+        private static readonly Dictionary<int, object> s_instances = new Dictionary<int, object>();
+        private static int s_nextHandle = 1; // 0 is the "no handle" sentinel
+
+        /// <summary>Register an instance and return its native handle (never 0).</summary>
+        public static int Register(object instance)
+        {
+            if (instance is null)
+            {
+                throw new ArgumentNullException(nameof(instance));
+            }
+
+            lock (s_lock)
+            {
+                int handle = s_nextHandle++;
+                if (s_nextHandle == 0)
+                {
+                    // Wrapped past int.MaxValue; skip the sentinel.
+                    s_nextHandle = 1;
+                }
+                s_instances[handle] = instance;
+                return handle;
+            }
+        }
+
+        /// <summary>Drop a handle. Safe to call more than once.</summary>
+        public static void Unregister(int handle)
+        {
+            lock (s_lock)
+            {
+                s_instances.Remove(handle);
+            }
+        }
+
+        /// <summary>Resolve a handle, or null if it is unknown or already released.</summary>
+        public static object? Resolve(int handle)
+        {
+            lock (s_lock)
+            {
+                return s_instances.TryGetValue(handle, out var instance) ? instance : null;
+            }
+        }
+
+        /// <summary>
+        /// Native entry point. Returns 1 if the call was dispatched, 0 if the
+        /// handle was dead or the component does not implement the callback -
+        /// in which case the native side simply does nothing (it must NOT fall
+        /// back to InvokeMethod here; a dead handle means the component is gone).
+        ///
+        /// Must never throw: an exception crossing an [UnmanagedCallersOnly]
+        /// boundary terminates the process.
+        /// </summary>
+        [UnmanagedCallersOnly]
+        public static int Invoke(int handle, int lifecycleId, float arg)
+        {
+            try
+            {
+                object? instance = Resolve(handle);
+                if (instance is null)
+                {
+                    return 0;
+                }
+
+                return Dispatch(instance, (LifecycleId)lifecycleId, arg) ? 1 : 0;
+            }
+            catch (Exception ex)
+            {
+                // Swallow: never let an exception cross the native boundary.
+                Debug.LogError($"ScriptComponentBridge.Invoke failed: {ex}");
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Route to the concrete callback. Separated from Invoke so it is
+        /// reachable from tests (Invoke itself is [UnmanagedCallersOnly] and
+        /// cannot be called from managed code).
+        /// </summary>
+        internal static bool Dispatch(object instance, LifecycleId id, float arg)
+        {
+            if (instance is not ScriptComponent component)
+            {
+                return false;
+            }
+
+            switch (id)
+            {
+                case LifecycleId.OnCreate:
+                    component.OnCreate();
+                    return true;
+                case LifecycleId.OnDestroy:
+                    component.OnDestroy();
+                    return true;
+                case LifecycleId.Tick:
+                    component.Tick(arg);
+                    return true;
+                case LifecycleId.OnTransformChanged:
+                    component.OnTransformChanged();
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/O3DE.Core/ScriptComponent.cs
+++ b/Assets/Scripts/O3DE.Core/ScriptComponent.cs
@@ -65,6 +65,11 @@ namespace O3DE
         /// </summary>
         private Transform? m_transform;
 
+        /// <summary>
+        /// Native bridge handle. Assigned on first acquire; 0 means unregistered.
+        /// </summary>
+        private int _bridgeHandle;
+
         #region Properties
 
         /// <summary>
@@ -155,6 +160,37 @@ namespace O3DE
         /// </summary>
         public virtual void OnDisable()
         {
+        }
+
+        #endregion
+
+        #region Native Bridge
+
+        /// <summary>
+        /// Register this instance with <see cref="O3DE.Interop.ScriptComponentBridge"/>
+        /// and return its native handle. Called once by native code immediately
+        /// after construction. Idempotent - repeated calls return the same handle.
+        /// </summary>
+        public int AcquireBridgeHandle()
+        {
+            if (_bridgeHandle == 0)
+            {
+                _bridgeHandle = O3DE.Interop.ScriptComponentBridge.Register(this);
+            }
+            return _bridgeHandle;
+        }
+
+        /// <summary>
+        /// Release the native bridge handle. Called by native code during
+        /// teardown, AFTER the final OnDestroy dispatch. Safe to call twice.
+        /// </summary>
+        public void ReleaseBridgeHandle()
+        {
+            if (_bridgeHandle != 0)
+            {
+                O3DE.Interop.ScriptComponentBridge.Unregister(_bridgeHandle);
+                _bridgeHandle = 0;
+            }
         }
 
         #endregion

--- a/Code/Source/Scripting/CSharpScriptComponent.cpp
+++ b/Code/Source/Scripting/CSharpScriptComponent.cpp
@@ -193,7 +193,10 @@ namespace O3DESharp
             {
                 SetEntityIdOnScript();
                 PushExposedPropertiesToScript();
-                SafeInvokeMethod("OnCreate");
+                if (!TryInvokeViaThunk(LifecycleId::OnCreate, 0.0f))
+                {
+                    SafeInvokeMethod("OnCreate");
+                }
             }
         }
     }
@@ -267,7 +270,10 @@ namespace O3DESharp
             PushExposedPropertiesToScript();
 
             // Call OnCreate on the managed instance
-            SafeInvokeMethod("OnCreate");
+            if (!TryInvokeViaThunk(LifecycleId::OnCreate, 0.0f))
+            {
+                SafeInvokeMethod("OnCreate");
+            }
         }
 
         // Connect to tick bus to call OnUpdate
@@ -307,9 +313,18 @@ namespace O3DESharp
 
         // Call OnDestroy before destroying the instance. Use the safe wrapper so
         // a throwing OnDestroy doesn't tear down the rest of the gem shutdown.
-        SafeInvokeMethod("OnDestroy");
+        //
+        // Ordering hazard: the bridge handle MUST still be registered for this
+        // dispatch. DestroyScriptInstance (below) is what unregisters it, and
+        // it runs strictly after this call - never reorder these two lines,
+        // or the thunk sees a dead handle and OnDestroy is silently skipped.
+        if (!TryInvokeViaThunk(LifecycleId::OnDestroy, 0.0f))
+        {
+            SafeInvokeMethod("OnDestroy");
+        }
 
-        // Destroy the managed instance
+        // Destroy the managed instance (also releases the bridge handle, AFTER
+        // the OnDestroy dispatch above).
         DestroyScriptInstance();
     }
 
@@ -353,7 +368,10 @@ namespace O3DESharp
             // The script can query the transform via the Transform API
             // We don't pass the transform data directly to avoid complex marshalling
             // Scripts that need to react to transform changes can override OnTransformChanged
-            SafeInvokeMethod("OnTransformChanged");
+            if (!TryInvokeViaThunk(LifecycleId::OnTransformChanged, 0.0f))
+            {
+                SafeInvokeMethod("OnTransformChanged");
+            }
         }
     }
 
@@ -499,9 +517,17 @@ namespace O3DESharp
         // mirrors what Deactivate does, giving user code a chance to clean
         // up state, but we use the safe wrapper so an exception inside
         // OnDestroy doesn't prevent the rest of the teardown.
+        //
+        // Ordering hazard: same as Deactivate. The bridge handle is still
+        // registered here - the context (and any cached thunk pointer into
+        // it) is only invalidated below, AFTER this dispatch and AFTER
+        // DestroyScriptInstance releases the handle.
         if (m_scriptInstance.IsValid())
         {
-            SafeInvokeMethod("OnDestroy");
+            if (!TryInvokeViaThunk(LifecycleId::OnDestroy, 0.0f))
+            {
+                SafeInvokeMethod("OnDestroy");
+            }
         }
         DestroyScriptInstance();
 
@@ -529,7 +555,10 @@ namespace O3DESharp
         {
             SetEntityIdOnScript();
             PushExposedPropertiesToScript();
-            SafeInvokeMethod("OnCreate");
+            if (!TryInvokeViaThunk(LifecycleId::OnCreate, 0.0f))
+            {
+                SafeInvokeMethod("OnCreate");
+            }
         }
 
         // Re-attach to TickBus so OnUpdate resumes firing.

--- a/Code/Source/Scripting/CSharpScriptComponent.cpp
+++ b/Code/Source/Scripting/CSharpScriptComponent.cpp
@@ -8,6 +8,7 @@
 
 #include "CSharpScriptComponent.h"
 #include "CoralHostManager.h"
+#include "CoralNativeThunkHost.h"
 
 #include <AzCore/Console/ILogger.h>
 #include <AzCore/Serialization/SerializeContext.h>
@@ -20,6 +21,20 @@
 
 namespace O3DESharp
 {
+    namespace
+    {
+        // Process-wide cache of resolved pinned thunks, shared by every
+        // CSharpScriptComponent instance. A single CoralHostManager backs the
+        // whole gem, so one CoralNativeThunkHost is enough here; SetHost() is
+        // a cheap no-op unless the host or scripts directory actually
+        // changed, so calling it from every CreateScriptInstance() is fine.
+        CoralNativeThunkHost& GetThunkHost()
+        {
+            static CoralNativeThunkHost s_thunkHost;
+            return s_thunkHost;
+        }
+    } // namespace
+
     // ============================================================
     // CSharpScriptComponentConfig
     // ============================================================
@@ -311,7 +326,14 @@ namespace O3DESharp
             // OnUpdate then ProcessPendingInvocations on the managed side. This
             // replaces the previous pair of InvokeMethod calls (one of which
             // was unconditional even when no actions were scheduled).
-            SafeInvokeMethod("Tick", deltaTime);
+            //
+            // Fast path: a resolved pinned thunk costs an indirect call plus a
+            // dictionary lookup. InvokeMethod would do a managed-side string
+            // lookup plus reflection dispatch - every frame, per component.
+            if (!TryInvokeViaThunk(LifecycleId::Tick, deltaTime))
+            {
+                SafeInvokeMethod("Tick", deltaTime);
+            }
         }
     }
 
@@ -333,6 +355,20 @@ namespace O3DESharp
             // Scripts that need to react to transform changes can override OnTransformChanged
             SafeInvokeMethod("OnTransformChanged");
         }
+    }
+
+    bool CSharpScriptComponent::TryInvokeViaThunk(LifecycleId id, float arg) noexcept
+    {
+        if (m_bridgeInvoke == nullptr || m_bridgeHandle == 0)
+        {
+            return false;
+        }
+
+        // A 0 return means the managed handle is dead (component torn down).
+        // That is NOT a reason to fall back to InvokeMethod - the instance is
+        // gone, so doing nothing is correct.
+        m_bridgeInvoke(m_bridgeHandle, static_cast<int>(id), arg);
+        return true;
     }
 
     void CSharpScriptComponent::SafeInvokeMethod(const char* methodName) noexcept
@@ -469,6 +505,14 @@ namespace O3DESharp
         }
         DestroyScriptInstance();
 
+        // The unified assembly context (O3DE.Core.dll included) is about to
+        // be unloaded by CoralHostManager::ReloadUserAssemblies, right after
+        // this broadcast finishes. Every pinned thunk resolved against it -
+        // including ScriptComponentBridge.Invoke - is about to dangle, so
+        // drop the cache now. Redundant across multiple components handling
+        // this same broadcast, but InvalidateCache() is just a map clear.
+        GetThunkHost().InvalidateCache();
+
         // Detach from TickBus so we don't try to dispatch into the now-
         // invalid context before OnAfterUserAssemblyReload reconstructs us.
         AZ::TickBus::Handler::BusDisconnect();
@@ -585,6 +629,19 @@ namespace O3DESharp
             return false;
         }
 
+        // Resolve the pinned thunk once per instance. Failure is expected and
+        // survivable: m_bridgeInvoke stays null and every call site falls back
+        // to SafeInvokeMethod.
+        CoralNativeThunkHost& thunkHost = GetThunkHost();
+        thunkHost.SetHost(hostManager->GetHostInstance(), hostManager->GetScriptsDirectory());
+        m_bridgeInvoke = reinterpret_cast<BridgeInvokeFn>(
+            thunkHost.Get("O3DE.Core.dll", "O3DE.Interop.ScriptComponentBridge, O3DE.Core", "Invoke"));
+
+        // One-shot, so InvokeMethod's cost is irrelevant here. Uses the same
+        // value-returning pattern already proven in the codebase (see
+        // O3DESharpSystemComponent.cpp: InvokeMethod<Coral::String>(...)).
+        m_bridgeHandle = m_scriptInstance.InvokeMethod<int>("AcquireBridgeHandle");
+
         m_scriptInitialized = true;
 
         AZLOG_INFO("CSharpScriptComponent: Successfully created script instance: '%s'",
@@ -597,9 +654,33 @@ namespace O3DESharp
     {
         if (m_scriptInstance.IsValid())
         {
+            // Release the native bridge handle before destroying the managed
+            // instance. Every caller of DestroyScriptInstance (Deactivate,
+            // OnBeforeUserAssemblyReload, ReloadScript, the destructor)
+            // dispatches OnDestroy first if it dispatches it at all, so the
+            // handle is guaranteed to still be live for that dispatch - this
+            // must run strictly after, never before.
+            if (m_bridgeHandle != 0)
+            {
+                try
+                {
+                    m_scriptInstance.InvokeMethod("ReleaseBridgeHandle");
+                }
+                catch (...)
+                {
+                    // Teardown must proceed regardless - the handle table
+                    // entry may leak in this case, but the alternative is an
+                    // exception escaping Deactivate/reload teardown.
+                    AZLOG_WARN("CSharpScriptComponent: ReleaseBridgeHandle threw during teardown of '%s'",
+                        m_config.m_scriptClassName.c_str());
+                }
+            }
+
             m_scriptInstance.Destroy();
         }
 
+        m_bridgeHandle = 0;
+        m_bridgeInvoke = nullptr;
         m_scriptType = nullptr;
         m_scriptInitialized = false;
     }

--- a/Code/Source/Scripting/CSharpScriptComponent.h
+++ b/Code/Source/Scripting/CSharpScriptComponent.h
@@ -245,6 +245,31 @@ namespace O3DESharp
         // Set after an unhandled exception in a lifecycle hook. Once true the
         // component stops dispatching to the managed instance.
         bool m_disabledByException = false;
+
+        //! Signature of ScriptComponentBridge.Invoke (see O3DE.Core's
+        //! Interop/ScriptComponentBridge.cs). Returns 1 if dispatched, 0 if
+        //! the handle was dead. Must match that method exactly.
+        using BridgeInvokeFn = int (*)(int handle, int lifecycleId, float arg);
+
+        //! Native handle for this component's managed instance, obtained from
+        //! ScriptComponentBridge.Register. 0 means "not registered".
+        int m_bridgeHandle = 0;
+
+        //! Resolved once; nullptr means "no thunk available, use InvokeMethod".
+        BridgeInvokeFn m_bridgeInvoke = nullptr;
+
+        //! Lifecycle ids - must match O3DE.Interop.LifecycleId exactly.
+        enum class LifecycleId : int
+        {
+            OnCreate = 1,
+            OnDestroy = 2,
+            Tick = 3,
+            OnTransformChanged = 4,
+        };
+
+        //! Try the pinned-thunk path. Returns false if unavailable, in which
+        //! case the caller MUST fall back to SafeInvokeMethod.
+        bool TryInvokeViaThunk(LifecycleId id, float arg) noexcept;
     };
 
     // Template implementations

--- a/Code/Source/Scripting/CoralHostManager.cpp
+++ b/Code/Source/Scripting/CoralHostManager.cpp
@@ -504,6 +504,26 @@ namespace O3DESharp
         return m_userAssembly;
     }
 
+    Coral::HostInstance* CoralHostManager::GetHostInstance()
+    {
+        return m_hostInstance.get();
+    }
+
+    AZ::IO::Path CoralHostManager::GetScriptsDirectory() const
+    {
+        // m_config.coreApiAssemblyPath is populated by LoadCoreAssembly (either
+        // from explicit config or the default <ProjectPath>/Bin/Scripts/O3DE.Core.dll
+        // derivation) - see LoadCoreAssembly below. Its parent directory is where
+        // every managed assembly (O3DE.Core.dll and user assemblies alike) is
+        // deployed, so the thunk host resolves other assemblies relative to it too.
+        if (m_config.coreApiAssemblyPath.empty())
+        {
+            return {};
+        }
+
+        return AZ::IO::Path(m_config.coreApiAssemblyPath.c_str()).ParentPath();
+    }
+
     bool CoralHostManager::LoadCoreAssembly()
     {
         if (m_config.coreApiAssemblyPath.empty())

--- a/Code/Source/Scripting/CoralHostManager.h
+++ b/Code/Source/Scripting/CoralHostManager.h
@@ -16,6 +16,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Interface/Interface.h>
+#include <AzCore/IO/Path/Path.h>
 
 #include <filesystem>
 
@@ -124,6 +125,22 @@ namespace O3DESharp
          * Get the user game assembly
          */
         virtual Coral::ManagedAssembly* GetUserAssembly() = 0;
+
+        /**
+         * Get the raw Coral host instance backing this manager. Used by
+         * CoralNativeThunkHost (SP-1a) to resolve [UnmanagedCallersOnly]
+         * managed statics to pinned function pointers; nullptr before the
+         * host has been constructed.
+         */
+        virtual Coral::HostInstance* GetHostInstance() = 0;
+
+        /**
+         * Get the directory managed assemblies are deployed to - the
+         * directory containing O3DE.Core.dll. Empty until the core assembly
+         * path has been resolved (i.e. after LoadCoreAssembly has run at
+         * least once during Initialize/ReloadUserAssemblies).
+         */
+        virtual AZ::IO::Path GetScriptsDirectory() const = 0;
     };
 
     using CoralHostManagerInterface = AZ::Interface<ICoralHostManager>;
@@ -159,6 +176,8 @@ namespace O3DESharp
         Coral::ManagedObject CreateInstance(Coral::Type& type) override;
         Coral::ManagedAssembly* GetCoreAssembly() override;
         Coral::ManagedAssembly* GetUserAssembly() override;
+        Coral::HostInstance* GetHostInstance() override;
+        AZ::IO::Path GetScriptsDirectory() const override;
 
     private:
         // Coral message callback for logging

--- a/Code/Source/Scripting/CoralNativeThunkHost.cpp
+++ b/Code/Source/Scripting/CoralNativeThunkHost.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include "CoralNativeThunkHost.h"
+
+#include <AzCore/Console/ILogger.h>
+#include <Coral/HostInstance.hpp>
+#include <Coral/StringHelper.hpp>
+
+#include <filesystem>
+
+namespace O3DESharp
+{
+    void CoralNativeThunkHost::SetHost(Coral::HostInstance* host, const AZ::IO::Path& scriptsDir)
+    {
+        if (m_host != host || m_scriptsDir != scriptsDir)
+        {
+            // Cached pointers belong to the previous host's runtime / layout.
+            m_cache.clear();
+            m_host = host;
+            m_scriptsDir = scriptsDir;
+        }
+    }
+
+    CoralNativeThunkHost::PinnedThunk CoralNativeThunkHost::Get(
+        AZStd::string_view assemblyFileName,
+        AZStd::string_view assemblyQualifiedTypeName,
+        AZStd::string_view methodName)
+    {
+        if (m_host == nullptr || m_scriptsDir.empty())
+        {
+            return nullptr;
+        }
+
+        AZStd::string key(assemblyFileName);
+        key += "!";
+        key += assemblyQualifiedTypeName;
+        key += "::";
+        key += methodName;
+
+        auto it = m_cache.find(key);
+        if (it != m_cache.end())
+        {
+            return it->second;
+        }
+
+        // Coral takes an assembly PATH plus UCChar strings. UCChar is wchar_t on
+        // Windows and char on Linux, and CORAL_STR() only works on literals, so
+        // runtime strings must go through ConvertUtf8ToWide. Paid once per
+        // unique key because the result (including nullptr) is memoized below.
+        //
+        // Composing the path via AZStd::string(...).c_str() (rather than
+        // AZ::IO::PathView) matches the existing precedent in this gem - see
+        // O3DESharpSystemComponent.cpp's userAssemblyPaths construction.
+        const AZ::IO::Path assemblyPath = m_scriptsDir / AZStd::string(assemblyFileName).c_str();
+
+        Coral::UCString typeNameUC = Coral::StringHelper::ConvertUtf8ToWide(
+            std::string_view(assemblyQualifiedTypeName.data(), assemblyQualifiedTypeName.size()));
+        Coral::UCString methodNameUC = Coral::StringHelper::ConvertUtf8ToWide(
+            std::string_view(methodName.data(), methodName.size()));
+
+        PinnedThunk thunk = m_host->GetFunctionPointer(
+            std::filesystem::path(assemblyPath.c_str()),
+            typeNameUC.c_str(),
+            methodNameUC.c_str());
+
+        if (thunk == nullptr)
+        {
+            AZLOG_WARN(
+                "[O3DESharp] No pinned thunk for %.*s::%.*s in %s - falling back to InvokeMethod",
+                static_cast<int>(assemblyQualifiedTypeName.size()), assemblyQualifiedTypeName.data(),
+                static_cast<int>(methodName.size()), methodName.data(),
+                assemblyPath.c_str());
+        }
+
+        // Memoize even nullptr: a failed resolution is stable, and caching
+        // it avoids re-attempting (and re-logging) on every frame.
+        m_cache[key] = thunk;
+        return thunk;
+    }
+
+    void CoralNativeThunkHost::InvalidateCache()
+    {
+        m_cache.clear();
+    }
+
+    size_t CoralNativeThunkHost::CachedCount() const
+    {
+        return m_cache.size();
+    }
+} // namespace O3DESharp

--- a/Code/Source/Scripting/CoralNativeThunkHost.h
+++ b/Code/Source/Scripting/CoralNativeThunkHost.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/string/string_view.h>
+#include <AzCore/std/containers/unordered_map.h>
+
+namespace Coral
+{
+    class HostInstance;
+}
+
+namespace O3DESharp
+{
+    //! Memoizing cache over Coral::HostInstance::GetFunctionPointer.
+    //!
+    //! Coral's only native->managed call path, ManagedObject::InvokeMethod,
+    //! does a managed-side string lookup plus reflection dispatch on EVERY
+    //! call. Resolving an [UnmanagedCallersOnly] static to a raw function
+    //! pointer once removes that cost from every subsequent call.
+    //!
+    //! Get() returns nullptr when the host is unset or resolution fails.
+    //! Callers MUST treat nullptr as "use InvokeMethod instead" - the
+    //! fallback is a first-class path, not an error case.
+    class CoralNativeThunkHost
+    {
+    public:
+        using PinnedThunk = void*;
+
+        //! Set the live host and the directory managed assemblies are deployed
+        //! to (the Bin/Scripts dir holding O3DE.Core.dll). Must be called after
+        //! CoralHostManager has brought up the CLR. Changing either clears the
+        //! cache.
+        void SetHost(Coral::HostInstance* host, const AZ::IO::Path& scriptsDir);
+
+        //! Resolve (and memoize) an [UnmanagedCallersOnly] managed static.
+        //! Returns nullptr when unavailable - callers MUST fall back to
+        //! InvokeMethod; that is a first-class path, not an error.
+        //!
+        //! assemblyFileName          e.g. "O3DE.Core.dll" (resolved under scriptsDir)
+        //! assemblyQualifiedTypeName e.g. "O3DE.Interop.ScriptComponentBridge, O3DE.Core"
+        //! methodName                e.g. "Invoke"
+        PinnedThunk Get(
+            AZStd::string_view assemblyFileName,
+            AZStd::string_view assemblyQualifiedTypeName,
+            AZStd::string_view methodName);
+
+        //! Drop all cached pointers. MUST be called on assembly reload -
+        //! a pointer into an unloaded ALC is dangling.
+        void InvalidateCache();
+
+        //! Diagnostic: number of currently memoized thunks.
+        size_t CachedCount() const;
+
+    private:
+        Coral::HostInstance* m_host = nullptr;
+        AZ::IO::Path m_scriptsDir;
+        AZStd::unordered_map<AZStd::string, PinnedThunk> m_cache;
+    };
+} // namespace O3DESharp

--- a/Code/o3desharp_private_files.cmake
+++ b/Code/o3desharp_private_files.cmake
@@ -21,6 +21,8 @@ set(FILES
     # C# Scripting Support via Coral
     Source/Scripting/CoralHostManager.h
     Source/Scripting/CoralHostManager.cpp
+    Source/Scripting/CoralNativeThunkHost.h
+    Source/Scripting/CoralNativeThunkHost.cpp
     Source/Scripting/ScriptBindings.h
     Source/Scripting/ScriptBindings.cpp
     Source/Scripting/CSharpScriptComponent.h

--- a/docs/superpowers/plans/2026-07-15-sp1a-native-managed-thunks.md
+++ b/docs/superpowers/plans/2026-07-15-sp1a-native-managed-thunks.md
@@ -40,6 +40,14 @@
 
 > **This task is in a different repository.** It gates Tasks 2, 4 and 7. Confirm with the maintainer whether they land it or delegate it.
 
+> ### ✅ TASK 1 IS COMPLETE — merged to `WatchDogStudios/Coral@main` as `a98550d` (PR #1).
+>
+> Do not redo it. It shipped **two** additive APIs, both compile-verified:
+> - `HostInstance::GetFunctionPointer(assemblyPath, typeName, methodName, delegateType = CORAL_UNMANAGED_CALLERS_ONLY)` — returns `nullptr` on failure, deliberately **not** forwarding to the internal loader (which `CORAL_VERIFY(false)`s and would abort the process instead of allowing fallback).
+> - `HostSettings::DotnetRootOverride` — for M2, unrelated to this plan.
+>
+> The steps below are retained only as a record of what was done.
+
 - [ ] **Step 1: Read the existing private path**
 
 Open `HostInstance.cpp` and locate `LoadCoralManagedFunctionPtr` and the `s_CoreCLRFunctions.GetManagedFunctionPtr` usage inside `InitializeCoralManaged`. This is the exact mechanism to expose — Coral already uses it to bootstrap `Coral.Managed`'s own entry points. Note the stored hostfxr context member (`m_HostFXRContext` or equivalent) and the delegate's real signature.
@@ -127,12 +135,25 @@ Note the pushed SHA. `Code/CMakeLists.txt` tracks `WatchDogStudios/Coral@main` v
 - Modify: `Code/o3desharp_private_files.cmake`
 
 **Interfaces:**
-- Consumes: `Coral::HostInstance::GetFunctionPointer` (Task 1).
+- Consumes (VERIFIED against merged Coral `main` @ `a98550d` — this is the real signature, not the one earlier drafts assumed):
+  ```cpp
+  void* Coral::HostInstance::GetFunctionPointer(
+      const std::filesystem::path& InAssemblyPath,
+      const UCChar* InTypeName,
+      const UCChar* InMethodName,
+      const UCChar* InDelegateType = CORAL_UNMANAGED_CALLERS_ONLY) const;
+  ```
 - Produces (consumed by Tasks 4, 7):
   - `using PinnedThunk = void*;`
-  - `void CoralNativeThunkHost::SetHost(Coral::HostInstance* host);`
-  - `PinnedThunk CoralNativeThunkHost::Get(AZStd::string_view assemblyQualifiedTypeName, AZStd::string_view methodName);` — returns `nullptr` if unavailable
+  - `void CoralNativeThunkHost::SetHost(Coral::HostInstance* host, const AZ::IO::Path& scriptsDir);`
+  - `PinnedThunk CoralNativeThunkHost::Get(AZStd::string_view assemblyFileName, AZStd::string_view assemblyQualifiedTypeName, AZStd::string_view methodName);` — returns `nullptr` if unavailable
   - `void CoralNativeThunkHost::InvalidateCache();`
+
+> **Three facts about the real Coral API that shape this design — do not skip:**
+>
+> 1. **It takes an assembly PATH, not just an assembly-qualified name.** Coral resolves `(assemblyPath, typeName, methodName)`. `O3DE.Core.dll` lives at `<ProjectPath>/Bin/Scripts/O3DE.Core.dll` (see `CoralHostManager.cpp:525`), so the thunk host must be told the scripts directory and compose the path itself.
+> 2. **`UCChar` is `wchar_t` on Windows and `char` on Linux**, and `CORAL_STR(s)` is a compile-time macro (`L##s`) that only works on string *literals* — it cannot be applied to a runtime `string_view`. Convert with the public helper `Coral::StringHelper::ConvertUtf8ToWide(std::string_view) -> UCString` (declared in `Coral/StringHelper.hpp`). Keeping the gem-side API narrow (`AZStd::string_view`) is deliberate: it matches surrounding AZ code and gives a natural cache key. The conversion cost is paid once per unique resolve because results are memoized.
+> 3. **`GetFunctionPointer` returns `nullptr` on failure and does NOT abort** — that is exactly why it exists rather than reusing Coral's internal loader, which `CORAL_VERIFY(false)`s. The whole fallback design depends on this. Do not "improve" it into an assert.
 
 - [ ] **Step 1: Read the rescued reference**
 
@@ -178,13 +199,23 @@ namespace O3DESharp
     public:
         using PinnedThunk = void*;
 
-        //! Set the live host. Must be called after CoralHostManager has
-        //! brought up the CLR. Passing a different host clears the cache.
-        void SetHost(Coral::HostInstance* host);
+        //! Set the live host and the directory managed assemblies are deployed
+        //! to (the Bin/Scripts dir holding O3DE.Core.dll). Must be called after
+        //! CoralHostManager has brought up the CLR. Changing either clears the
+        //! cache.
+        void SetHost(Coral::HostInstance* host, const AZ::IO::Path& scriptsDir);
 
-        //! Resolve (and memoize) a managed static. nullptr => not available.
+        //! Resolve (and memoize) an [UnmanagedCallersOnly] managed static.
+        //! Returns nullptr when unavailable - callers MUST fall back to
+        //! InvokeMethod; that is a first-class path, not an error.
+        //!
+        //! assemblyFileName          e.g. "O3DE.Core.dll" (resolved under scriptsDir)
         //! assemblyQualifiedTypeName e.g. "O3DE.Interop.ScriptComponentBridge, O3DE.Core"
-        PinnedThunk Get(AZStd::string_view assemblyQualifiedTypeName, AZStd::string_view methodName);
+        //! methodName                e.g. "Invoke"
+        PinnedThunk Get(
+            AZStd::string_view assemblyFileName,
+            AZStd::string_view assemblyQualifiedTypeName,
+            AZStd::string_view methodName);
 
         //! Drop all cached pointers. MUST be called on assembly reload -
         //! a pointer into an unloaded ALC is dangling.
@@ -195,10 +226,13 @@ namespace O3DESharp
 
     private:
         Coral::HostInstance* m_host = nullptr;
+        AZ::IO::Path m_scriptsDir;
         AZStd::unordered_map<AZStd::string, PinnedThunk> m_cache;
     };
 } // namespace O3DESharp
 ```
+
+Add `#include <AzCore/IO/Path/Path.h>` alongside the other AzCore includes for `AZ::IO::Path`.
 
 - [ ] **Step 3: Write the implementation**
 
@@ -216,28 +250,34 @@ Create `Code/Source/Scripting/CoralNativeThunkHost.cpp`:
 
 #include <AzCore/Console/ILogger.h>
 #include <Coral/HostInstance.hpp>
+#include <Coral/StringHelper.hpp>
 
 namespace O3DESharp
 {
-    void CoralNativeThunkHost::SetHost(Coral::HostInstance* host)
+    void CoralNativeThunkHost::SetHost(Coral::HostInstance* host, const AZ::IO::Path& scriptsDir)
     {
-        if (m_host != host)
+        if (m_host != host || m_scriptsDir != scriptsDir)
         {
-            // Cached pointers belong to the previous host's runtime.
+            // Cached pointers belong to the previous host's runtime / layout.
             m_cache.clear();
             m_host = host;
+            m_scriptsDir = scriptsDir;
         }
     }
 
     CoralNativeThunkHost::PinnedThunk CoralNativeThunkHost::Get(
-        AZStd::string_view assemblyQualifiedTypeName, AZStd::string_view methodName)
+        AZStd::string_view assemblyFileName,
+        AZStd::string_view assemblyQualifiedTypeName,
+        AZStd::string_view methodName)
     {
-        if (m_host == nullptr)
+        if (m_host == nullptr || m_scriptsDir.empty())
         {
             return nullptr;
         }
 
-        AZStd::string key(assemblyQualifiedTypeName);
+        AZStd::string key(assemblyFileName);
+        key += "!";
+        key += assemblyQualifiedTypeName;
         key += "::";
         key += methodName;
 
@@ -247,16 +287,29 @@ namespace O3DESharp
             return it->second;
         }
 
-        PinnedThunk thunk = m_host->GetFunctionPointer(
-            std::string_view(assemblyQualifiedTypeName.data(), assemblyQualifiedTypeName.size()),
+        // Coral takes an assembly PATH plus UCChar strings. UCChar is wchar_t on
+        // Windows and char on Linux, and CORAL_STR() only works on literals, so
+        // runtime strings must go through ConvertUtf8ToWide. Paid once per
+        // unique key because the result (including nullptr) is memoized below.
+        const AZ::IO::Path assemblyPath = m_scriptsDir / AZ::IO::PathView(assemblyFileName);
+
+        Coral::UCString typeNameUC = Coral::StringHelper::ConvertUtf8ToWide(
+            std::string_view(assemblyQualifiedTypeName.data(), assemblyQualifiedTypeName.size()));
+        Coral::UCString methodNameUC = Coral::StringHelper::ConvertUtf8ToWide(
             std::string_view(methodName.data(), methodName.size()));
+
+        PinnedThunk thunk = m_host->GetFunctionPointer(
+            std::filesystem::path(assemblyPath.c_str()),
+            typeNameUC.c_str(),
+            methodNameUC.c_str());
 
         if (thunk == nullptr)
         {
             AZLOG_WARN(
-                "[O3DESharp] No pinned thunk for %.*s::%.*s - falling back to InvokeMethod",
+                "[O3DESharp] No pinned thunk for %.*s::%.*s in %s - falling back to InvokeMethod",
                 static_cast<int>(assemblyQualifiedTypeName.size()), assemblyQualifiedTypeName.data(),
-                static_cast<int>(methodName.size()), methodName.data());
+                static_cast<int>(methodName.size()), methodName.data(),
+                assemblyPath.c_str());
         }
 
         // Memoize even nullptr: a failed resolution is stable, and caching
@@ -296,7 +349,13 @@ import pathlib
 h = pathlib.Path('Code/Source/Scripting/CoralNativeThunkHost.h').read_text(encoding='utf-8')
 c = pathlib.Path('Code/Source/Scripting/CoralNativeThunkHost.cpp').read_text(encoding='utf-8')
 cm = pathlib.Path('Code/o3desharp_private_files.cmake').read_text(encoding='utf-8')
-assert 'hostfxr' not in (h+c).lower(), 'hostfxr re-init must NOT be carried forward'
+import re
+# The rescued prototype called hostfxr_initialize_for_runtime_config itself.
+# That must NOT be carried forward - Coral's GetFunctionPointer replaced the
+# need. Match the actual API calls, not the word 'hostfxr', which legitimately
+# appears in explanatory comments.
+banned = re.findall(r'hostfxr_[a-z_]+\s*\(', (h + c))
+assert not banned, f'hostfxr re-init must NOT be carried forward: {banned}'
 for m in ('SetHost','Get(','InvalidateCache','CachedCount'):
     assert m in h and m.split('(')[0] in c, m
 assert 'CoralNativeThunkHost.cpp' in cm and 'CoralNativeThunkHost.h' in cm
@@ -735,7 +794,7 @@ Where `m_scriptInstance` is created (after it is valid), resolve the thunk and r
         // Resolve the pinned thunk once per instance. Failure is expected and
         // survivable: m_bridgeInvoke stays null and every call site falls back.
         m_bridgeInvoke = reinterpret_cast<BridgeInvokeFn>(
-            thunkHost.Get("O3DE.Interop.ScriptComponentBridge, O3DE.Core", "Invoke"));
+            thunkHost.Get("O3DE.Core.dll", "O3DE.Interop.ScriptComponentBridge, O3DE.Core", "Invoke"));
 
         // One-shot, so InvokeMethod's cost is irrelevant here. Uses the same
         // value-returning pattern already proven in the codebase (see

--- a/docs/superpowers/plans/2026-07-15-sp1a-native-managed-thunks.md
+++ b/docs/superpowers/plans/2026-07-15-sp1a-native-managed-thunks.md
@@ -1,0 +1,1053 @@
+# SP-1a Native→Managed Pinned Thunks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the per-call string-lookup + .NET-reflection cost from every native→managed call, starting with `CSharpScriptComponent`'s per-frame `Tick`.
+
+**Architecture:** Add a public function-pointer API to the Coral fork, use it to resolve `[UnmanagedCallersOnly]` managed entry points into raw callable pointers once, and route `CSharpScriptComponent`'s lifecycle calls through those pointers — keeping `Coral::ManagedObject::InvokeMethod` as an always-available fallback so a resolution failure degrades to today's behaviour rather than breaking.
+
+**Tech Stack:** C++ (AzCore, Coral), C# (`O3DE.Core`, `[UnmanagedCallersOnly]`), .NET hosting (`hostfxr` / `load_assembly_and_get_function_pointer`), xUnit.
+
+## Global Constraints
+
+- This is **Half A only** of SP-1 (`docs/superpowers/specs/2026-07-15-sp1-marshaling-core-design.md`). The manifest / trampoline / `BindingRegistry` work is **Half B** and gets its own plan. Do not start it here.
+- **Determinism / sim-lane scope is explicitly dropped** (spec §10). Ignore `ISimSystem` / `SimSystemBase` / tiering-lock references in the rescued comments — that second half was never written and is not in scope.
+- **The fallback is mandatory and first-class.** Every thunk call site must fall back to `InvokeMethod` when the thunk is unavailable. A resolution failure is a performance regression, never a functional one.
+- **No C++ in this repository can be compile-verified in the development environment** (no O3DE engine SDK present). C++ tasks must be authored against real, existing signatures — read the file before editing it — and every C++ commit message must state that it is not compile-verified. The maintainer verifies via a real engine build.
+- **Task 1 is CROSS-REPO** (`WatchDogStudios/Coral`) and gates Tasks 2, 4, 7.
+- Commit messages must contain **no** Claude/Anthropic co-author or attribution trailers.
+- The rescued code (`Rescued/1b-native-trampoline/`, branch `feat/1b-native-trampoline-rescue`) is **unfinished and has never been compiled**. Treat it as a reference for *analysis and intent*, not as code to paste unchanged (spec §11.3).
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `WatchDogStudios/Coral` → `HostInstance.hpp/.cpp` (modify, **cross-repo**) | Public `GetFunctionPointer` returning a raw callable pointer for an `[UnmanagedCallersOnly]` managed static. |
+| `Code/Source/Scripting/CoralNativeThunkHost.h/.cpp` (create) | Thin cache over the Coral API: resolve once, memoize by (type, method), invalidate on reload. No hostfxr handling of its own. |
+| `Assets/Scripts/O3DE.Core/Interop/ScriptComponentBridge.cs` (create) | Managed side: an instance-handle table plus the `[UnmanagedCallersOnly]` entry point that dispatches to a live `ScriptComponent`. |
+| `Assets/Scripts/O3DE.Core.Tests/Interop/ScriptComponentBridgeTests.cs` (create) | Tests for the handle table and dispatch routing (the parts testable without a host). |
+| `Code/Source/Scripting/CSharpScriptComponent.cpp/.h` (modify) | Route lifecycle calls through the thunk with `InvokeMethod` fallback. |
+
+---
+
+### Task 1: Coral fork — public function-pointer API — **CROSS-REPO**
+
+**Files:**
+- Modify (in a `WatchDogStudios/Coral` checkout): `Coral.Native/Include/Coral/HostInstance.hpp`, `Coral.Native/Source/Coral/HostInstance.cpp`
+
+**Interfaces:**
+- Produces (consumed by Task 2): `void* Coral::HostInstance::GetFunctionPointer(std::string_view assemblyQualifiedTypeName, std::string_view methodName)` — returns `nullptr` on failure, never throws.
+
+> **This task is in a different repository.** It gates Tasks 2, 4 and 7. Confirm with the maintainer whether they land it or delegate it.
+
+- [ ] **Step 1: Read the existing private path**
+
+Open `HostInstance.cpp` and locate `LoadCoralManagedFunctionPtr` and the `s_CoreCLRFunctions.GetManagedFunctionPtr` usage inside `InitializeCoralManaged`. This is the exact mechanism to expose — Coral already uses it to bootstrap `Coral.Managed`'s own entry points. Note the stored hostfxr context member (`m_HostFXRContext` or equivalent) and the delegate's real signature.
+
+- [ ] **Step 2: Declare the public API**
+
+In `HostInstance.hpp`, inside the `HostInstance` public section:
+
+```cpp
+        /// Resolve an [UnmanagedCallersOnly] managed static to a raw,
+        /// natively-callable function pointer. Resolution happens once;
+        /// the returned pointer has no per-call managed lookup or
+        /// reflection cost, unlike InvokeMethod.
+        ///
+        /// assemblyQualifiedTypeName: e.g. "O3DE.Interop.ScriptComponentBridge, O3DE.Core"
+        /// methodName:                the static method's name
+        ///
+        /// Returns nullptr if the host is not initialized or resolution
+        /// fails. Never throws - callers are expected to fall back to
+        /// InvokeMethod.
+        void* GetFunctionPointer(std::string_view assemblyQualifiedTypeName, std::string_view methodName);
+```
+
+- [ ] **Step 3: Implement it**
+
+In `HostInstance.cpp`, implement by delegating to the same mechanism `LoadCoralManagedFunctionPtr` uses. Adapt the body to the fork's actual member and delegate names discovered in Step 1 — do not invent names:
+
+```cpp
+    void* HostInstance::GetFunctionPointer(std::string_view assemblyQualifiedTypeName, std::string_view methodName)
+    {
+        if (!m_Initialized)
+        {
+            return nullptr;
+        }
+
+        void* functionPtr = nullptr;
+        // UNMANAGEDCALLERSONLY_METHOD tells the runtime the target carries
+        // [UnmanagedCallersOnly], so no delegate type name is required.
+        const int status = s_CoreCLRFunctions.GetManagedFunctionPtr(
+            std::string(assemblyQualifiedTypeName).c_str(),
+            std::string(methodName).c_str(),
+            UNMANAGEDCALLERSONLY_METHOD,
+            nullptr,
+            nullptr,
+            &functionPtr);
+
+        return (status == 0) ? functionPtr : nullptr;
+    }
+```
+
+- [ ] **Step 4: Build the Coral fork**
+
+Build Coral.Native per its own README.
+Expected: builds clean. If `GetManagedFunctionPtr`'s signature differs from the above, match the actual one — the semantic requirement is only "resolve an `[UnmanagedCallersOnly]` static to a raw pointer, return nullptr on failure."
+
+- [ ] **Step 5: Commit and push in the Coral repository**
+
+```bash
+git add Coral.Native/Include/Coral/HostInstance.hpp Coral.Native/Source/Coral/HostInstance.cpp
+git commit -m "Add HostInstance::GetFunctionPointer for [UnmanagedCallersOnly] statics
+
+Coral exposed exactly one native->managed path, ManagedObject::InvokeMethod,
+which performs a managed-side string lookup plus reflection dispatch on every
+call. The reverse direction (AddInternalCall) has been a zero-per-call pinned
+thunk all along; this closes that asymmetry.
+
+Uses the same GetManagedFunctionPtr mechanism HostInstance already uses to
+bootstrap Coral.Managed's own entry points - it simply makes it available to
+embedders for their own assemblies. Returns nullptr on failure so callers can
+fall back to InvokeMethod."
+git push
+```
+
+- [ ] **Step 6: Record the resolved commit for the gem**
+
+Note the pushed SHA. `Code/CMakeLists.txt` tracks `WatchDogStudios/Coral@main` via FetchContent, so a fresh configure picks it up; record the SHA in Task 2's commit message for traceability.
+
+---
+
+### Task 2: CoralNativeThunkHost on the Coral API
+
+**Files:**
+- Create: `Code/Source/Scripting/CoralNativeThunkHost.h`
+- Create: `Code/Source/Scripting/CoralNativeThunkHost.cpp`
+- Modify: `Code/o3desharp_private_files.cmake`
+
+**Interfaces:**
+- Consumes: `Coral::HostInstance::GetFunctionPointer` (Task 1).
+- Produces (consumed by Tasks 4, 7):
+  - `using PinnedThunk = void*;`
+  - `void CoralNativeThunkHost::SetHost(Coral::HostInstance* host);`
+  - `PinnedThunk CoralNativeThunkHost::Get(AZStd::string_view assemblyQualifiedTypeName, AZStd::string_view methodName);` — returns `nullptr` if unavailable
+  - `void CoralNativeThunkHost::InvalidateCache();`
+
+- [ ] **Step 1: Read the rescued reference**
+
+Read `Rescued/1b-native-trampoline/Code/Source/Scripting/CoralNativeThunkHost.h` (on branch `feat/1b-native-trampoline-rescue`). Its analysis is correct and worth understanding, **but its implementation independently re-initializes hostfxr** because an earlier task forbade touching Coral. That constraint no longer applies. **Do not carry the hostfxr re-initialization forward** — Task 1 replaced the need for it.
+
+- [ ] **Step 2: Write the header**
+
+Create `Code/Source/Scripting/CoralNativeThunkHost.h`:
+
+```cpp
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/string/string_view.h>
+#include <AzCore/std/containers/unordered_map.h>
+
+namespace Coral
+{
+    class HostInstance;
+}
+
+namespace O3DESharp
+{
+    //! Memoizing cache over Coral::HostInstance::GetFunctionPointer.
+    //!
+    //! Coral's only native->managed call path, ManagedObject::InvokeMethod,
+    //! does a managed-side string lookup plus reflection dispatch on EVERY
+    //! call. Resolving an [UnmanagedCallersOnly] static to a raw function
+    //! pointer once removes that cost from every subsequent call.
+    //!
+    //! Get() returns nullptr when the host is unset or resolution fails.
+    //! Callers MUST treat nullptr as "use InvokeMethod instead" - the
+    //! fallback is a first-class path, not an error case.
+    class CoralNativeThunkHost
+    {
+    public:
+        using PinnedThunk = void*;
+
+        //! Set the live host. Must be called after CoralHostManager has
+        //! brought up the CLR. Passing a different host clears the cache.
+        void SetHost(Coral::HostInstance* host);
+
+        //! Resolve (and memoize) a managed static. nullptr => not available.
+        //! assemblyQualifiedTypeName e.g. "O3DE.Interop.ScriptComponentBridge, O3DE.Core"
+        PinnedThunk Get(AZStd::string_view assemblyQualifiedTypeName, AZStd::string_view methodName);
+
+        //! Drop all cached pointers. MUST be called on assembly reload -
+        //! a pointer into an unloaded ALC is dangling.
+        void InvalidateCache();
+
+        //! Diagnostic: number of currently memoized thunks.
+        size_t CachedCount() const;
+
+    private:
+        Coral::HostInstance* m_host = nullptr;
+        AZStd::unordered_map<AZStd::string, PinnedThunk> m_cache;
+    };
+} // namespace O3DESharp
+```
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Code/Source/Scripting/CoralNativeThunkHost.cpp`:
+
+```cpp
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include "CoralNativeThunkHost.h"
+
+#include <AzCore/Console/ILogger.h>
+#include <Coral/HostInstance.hpp>
+
+namespace O3DESharp
+{
+    void CoralNativeThunkHost::SetHost(Coral::HostInstance* host)
+    {
+        if (m_host != host)
+        {
+            // Cached pointers belong to the previous host's runtime.
+            m_cache.clear();
+            m_host = host;
+        }
+    }
+
+    CoralNativeThunkHost::PinnedThunk CoralNativeThunkHost::Get(
+        AZStd::string_view assemblyQualifiedTypeName, AZStd::string_view methodName)
+    {
+        if (m_host == nullptr)
+        {
+            return nullptr;
+        }
+
+        AZStd::string key(assemblyQualifiedTypeName);
+        key += "::";
+        key += methodName;
+
+        auto it = m_cache.find(key);
+        if (it != m_cache.end())
+        {
+            return it->second;
+        }
+
+        PinnedThunk thunk = m_host->GetFunctionPointer(
+            std::string_view(assemblyQualifiedTypeName.data(), assemblyQualifiedTypeName.size()),
+            std::string_view(methodName.data(), methodName.size()));
+
+        if (thunk == nullptr)
+        {
+            AZLOG_WARN(
+                "[O3DESharp] No pinned thunk for %.*s::%.*s - falling back to InvokeMethod",
+                static_cast<int>(assemblyQualifiedTypeName.size()), assemblyQualifiedTypeName.data(),
+                static_cast<int>(methodName.size()), methodName.data());
+        }
+
+        // Memoize even nullptr: a failed resolution is stable, and caching
+        // it avoids re-attempting (and re-logging) on every frame.
+        m_cache[key] = thunk;
+        return thunk;
+    }
+
+    void CoralNativeThunkHost::InvalidateCache()
+    {
+        m_cache.clear();
+    }
+
+    size_t CoralNativeThunkHost::CachedCount() const
+    {
+        return m_cache.size();
+    }
+} // namespace O3DESharp
+```
+
+- [ ] **Step 4: Add to the build**
+
+In `Code/o3desharp_private_files.cmake`, add to the `FILES` list, keeping alphabetical order with its neighbours:
+
+```cmake
+    Source/Scripting/CoralNativeThunkHost.cpp
+    Source/Scripting/CoralNativeThunkHost.h
+```
+
+- [ ] **Step 5: Verify what can be verified here**
+
+C++ cannot be compiled in this environment. Verify mechanically instead:
+
+```bash
+python -c "
+import pathlib
+h = pathlib.Path('Code/Source/Scripting/CoralNativeThunkHost.h').read_text(encoding='utf-8')
+c = pathlib.Path('Code/Source/Scripting/CoralNativeThunkHost.cpp').read_text(encoding='utf-8')
+cm = pathlib.Path('Code/o3desharp_private_files.cmake').read_text(encoding='utf-8')
+assert 'hostfxr' not in (h+c).lower(), 'hostfxr re-init must NOT be carried forward'
+for m in ('SetHost','Get(','InvalidateCache','CachedCount'):
+    assert m in h and m.split('(')[0] in c, m
+assert 'CoralNativeThunkHost.cpp' in cm and 'CoralNativeThunkHost.h' in cm
+print('structural checks pass')
+"
+```
+Expected: `structural checks pass`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Code/Source/Scripting/CoralNativeThunkHost.h Code/Source/Scripting/CoralNativeThunkHost.cpp Code/o3desharp_private_files.cmake
+git commit -m "SP-1a: memoizing thunk cache over Coral's new GetFunctionPointer
+
+Resolves [UnmanagedCallersOnly] managed statics to raw function pointers once
+and caches them, removing the per-call string lookup + reflection dispatch that
+ManagedObject::InvokeMethod performs.
+
+Unlike the rescued 1B prototype this does NOT re-initialize hostfxr itself -
+that workaround only existed because an earlier task could not modify Coral.
+It now uses HostInstance::GetFunctionPointer (Coral fork <SHA from Task 1>).
+
+Caches negative results too, so a missing thunk does not re-log every frame.
+NOT COMPILE-VERIFIED: no O3DE engine SDK in the authoring environment."
+```
+
+---
+
+### Task 3: Managed bridge — handle table + `[UnmanagedCallersOnly]` entry point
+
+**Files:**
+- Create: `Assets/Scripts/O3DE.Core/Interop/ScriptComponentBridge.cs`
+- Test: `Assets/Scripts/O3DE.Core.Tests/Interop/ScriptComponentBridgeTests.cs`
+
+**Interfaces:**
+- Produces (consumed by Tasks 4, 7):
+  - `static int ScriptComponentBridge.Register(object instance)` → handle (never 0)
+  - `static void ScriptComponentBridge.Unregister(int handle)`
+  - `static object? ScriptComponentBridge.Resolve(int handle)`
+  - `[UnmanagedCallersOnly] static int ScriptComponentBridge.Invoke(int handle, int lifecycleId, float arg)` → 1 on success, 0 if unhandled
+  - `enum LifecycleId { OnCreate = 1, OnDestroy = 2, Tick = 3, OnTransformChanged = 4 }`
+
+> **Why a handle table:** the thunk target must be a **static** method, but the calls are instance lifecycle callbacks. C++ holds an opaque `int` handle per component and passes it back; the managed side resolves it to the live instance with an array index, not reflection. Using our own table (rather than Coral's internal object handles) keeps this independent of Coral internals.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Assets/Scripts/O3DE.Core.Tests/Interop/ScriptComponentBridgeTests.cs`:
+
+```csharp
+//
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// For complete copyright and license terms please see the LICENSE at the root of this distribution.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+using System;
+using O3DE.Interop;
+
+namespace O3DE.Core.Tests.Interop;
+
+/// <summary>
+/// The handle table is what makes a STATIC [UnmanagedCallersOnly] thunk able to
+/// service INSTANCE lifecycle callbacks: C++ holds an opaque int per component
+/// and hands it back on every call. These pin the properties the native side
+/// relies on - handles are never 0 (0 is the native "no handle" sentinel),
+/// they are not reused while live, and resolving a stale handle is safe.
+/// </summary>
+public class ScriptComponentBridgeTests
+{
+    [Fact]
+    public void Register_ReturnsNonZeroHandle()
+    {
+        var handle = ScriptComponentBridge.Register(new object());
+        try
+        {
+            handle.Should().NotBe(0, "0 is the native sentinel for 'no handle'");
+        }
+        finally
+        {
+            ScriptComponentBridge.Unregister(handle);
+        }
+    }
+
+    [Fact]
+    public void Resolve_ReturnsTheRegisteredInstance()
+    {
+        var instance = new object();
+        var handle = ScriptComponentBridge.Register(instance);
+        try
+        {
+            ScriptComponentBridge.Resolve(handle).Should().BeSameAs(instance);
+        }
+        finally
+        {
+            ScriptComponentBridge.Unregister(handle);
+        }
+    }
+
+    [Fact]
+    public void DistinctInstances_GetDistinctHandles()
+    {
+        var a = ScriptComponentBridge.Register(new object());
+        var b = ScriptComponentBridge.Register(new object());
+        try
+        {
+            a.Should().NotBe(b);
+        }
+        finally
+        {
+            ScriptComponentBridge.Unregister(a);
+            ScriptComponentBridge.Unregister(b);
+        }
+    }
+
+    [Fact]
+    public void Resolve_AfterUnregister_ReturnsNull()
+    {
+        var handle = ScriptComponentBridge.Register(new object());
+        ScriptComponentBridge.Unregister(handle);
+
+        // Native code can legitimately race a teardown against an in-flight
+        // tick; resolving a dead handle must be safe, not throw.
+        ScriptComponentBridge.Resolve(handle).Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_UnknownHandle_ReturnsNull()
+    {
+        ScriptComponentBridge.Resolve(0).Should().BeNull();
+        ScriptComponentBridge.Resolve(999999).Should().BeNull();
+        ScriptComponentBridge.Resolve(-1).Should().BeNull();
+    }
+
+    [Fact]
+    public void Unregister_IsIdempotent()
+    {
+        var handle = ScriptComponentBridge.Register(new object());
+        ScriptComponentBridge.Unregister(handle);
+
+        // Double-unregister must not throw - teardown paths can run twice.
+        var act = () => ScriptComponentBridge.Unregister(handle);
+        act.Should().NotThrow();
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test Assets/Scripts/O3DE.Core.Tests/O3DE.Core.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~ScriptComponentBridgeTests"`
+Expected: build failure — `O3DE.Interop` / `ScriptComponentBridge` does not exist.
+
+- [ ] **Step 3: Implement the bridge**
+
+Create `Assets/Scripts/O3DE.Core/Interop/ScriptComponentBridge.cs`:
+
+```csharp
+//
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// For complete copyright and license terms please see the LICENSE at the root of this distribution.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace O3DE.Interop
+{
+    /// <summary>
+    /// Which lifecycle callback a native Invoke is requesting. Values are part
+    /// of the native ABI - C++ passes these integers - so they must never be
+    /// renumbered without changing CSharpScriptComponent.cpp in lockstep.
+    /// </summary>
+    public enum LifecycleId
+    {
+        OnCreate = 1,
+        OnDestroy = 2,
+        Tick = 3,
+        OnTransformChanged = 4,
+    }
+
+    /// <summary>
+    /// The native-callable entry point for script component lifecycle calls.
+    ///
+    /// Coral's ManagedObject.InvokeMethod does a managed-side string lookup plus
+    /// reflection dispatch on every call, which for Tick means every frame per
+    /// component. This bridge is resolved once to a raw function pointer via
+    /// Coral's GetFunctionPointer, after which calls cost an indirect call plus
+    /// an array index.
+    ///
+    /// The thunk target must be static, but lifecycle callbacks are per
+    /// instance, so C++ holds an opaque int handle per component and passes it
+    /// back on every call. Handle 0 is reserved as the native "no handle"
+    /// sentinel and is never issued.
+    /// </summary>
+    public static class ScriptComponentBridge
+    {
+        private static readonly object s_lock = new object();
+        private static readonly Dictionary<int, object> s_instances = new Dictionary<int, object>();
+        private static int s_nextHandle = 1; // 0 is the "no handle" sentinel
+
+        /// <summary>Register an instance and return its native handle (never 0).</summary>
+        public static int Register(object instance)
+        {
+            if (instance is null)
+            {
+                throw new ArgumentNullException(nameof(instance));
+            }
+
+            lock (s_lock)
+            {
+                int handle = s_nextHandle++;
+                if (s_nextHandle == 0)
+                {
+                    // Wrapped past int.MaxValue; skip the sentinel.
+                    s_nextHandle = 1;
+                }
+                s_instances[handle] = instance;
+                return handle;
+            }
+        }
+
+        /// <summary>Drop a handle. Safe to call more than once.</summary>
+        public static void Unregister(int handle)
+        {
+            lock (s_lock)
+            {
+                s_instances.Remove(handle);
+            }
+        }
+
+        /// <summary>Resolve a handle, or null if it is unknown or already released.</summary>
+        public static object? Resolve(int handle)
+        {
+            lock (s_lock)
+            {
+                return s_instances.TryGetValue(handle, out var instance) ? instance : null;
+            }
+        }
+
+        /// <summary>
+        /// Native entry point. Returns 1 if the call was dispatched, 0 if the
+        /// handle was dead or the component does not implement the callback -
+        /// in which case the native side simply does nothing (it must NOT fall
+        /// back to InvokeMethod here; a dead handle means the component is gone).
+        ///
+        /// Must never throw: an exception crossing an [UnmanagedCallersOnly]
+        /// boundary terminates the process.
+        /// </summary>
+        [UnmanagedCallersOnly]
+        public static int Invoke(int handle, int lifecycleId, float arg)
+        {
+            try
+            {
+                object? instance = Resolve(handle);
+                if (instance is null)
+                {
+                    return 0;
+                }
+
+                return Dispatch(instance, (LifecycleId)lifecycleId, arg) ? 1 : 0;
+            }
+            catch (Exception ex)
+            {
+                // Swallow: never let an exception cross the native boundary.
+                Debug.LogError($"ScriptComponentBridge.Invoke failed: {ex}");
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Route to the concrete callback. Separated from Invoke so it is
+        /// reachable from tests (Invoke itself is [UnmanagedCallersOnly] and
+        /// cannot be called from managed code).
+        /// </summary>
+        internal static bool Dispatch(object instance, LifecycleId id, float arg)
+        {
+            if (instance is not ScriptComponent component)
+            {
+                return false;
+            }
+
+            switch (id)
+            {
+                case LifecycleId.OnCreate:
+                    component.OnCreate();
+                    return true;
+                case LifecycleId.OnDestroy:
+                    component.OnDestroy();
+                    return true;
+                case LifecycleId.Tick:
+                    component.Tick(arg);
+                    return true;
+                case LifecycleId.OnTransformChanged:
+                    component.OnTransformChanged();
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Reconcile against the real `ScriptComponent`**
+
+Verified against `Assets/Scripts/O3DE.Core/ScriptComponent.cs` on 2026-07-15:
+
+| Member | Line | Kind | Used by `Dispatch` as |
+|---|---|---|---|
+| `OnCreate()` | 118 | `public virtual` | direct call |
+| `OnUpdate(float)` | 126 | `public virtual` | **not called directly** |
+| `OnDestroy()` | 134 | `public virtual` | direct call |
+| `OnTransformChanged()` | 142 | `public virtual` | direct call |
+| `Tick(float)` | 339 | `public` **non-virtual** | direct call |
+
+**The `Tick` / `OnUpdate` distinction matters.** `Tick(float)` is the native entry point (it is what `SafeInvokeMethod("Tick", dt)` calls today) and it internally drives the `Invoke`/`InvokeRepeating` timer machinery *and* the virtual `OnUpdate`. `Dispatch` must therefore call **`Tick`**, not `OnUpdate` — calling `OnUpdate` directly would silently skip the delayed-invoke bookkeeping. Conversely, user code and test probes override **`OnUpdate`**, because `Tick` is not virtual.
+
+Confirm these still hold before proceeding; if the class has changed, adjust `Dispatch` to match it rather than renaming the existing API.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet test Assets/Scripts/O3DE.Core.Tests/O3DE.Core.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~ScriptComponentBridgeTests"`
+Expected: `Passed! - Failed: 0, Passed: 6`
+
+- [ ] **Step 6: Run the full managed suite**
+
+Run: `dotnet test Assets/Scripts/O3DE.Core.Tests/O3DE.Core.Tests.csproj -c Release --nologo`
+Expected: all pass (previous count plus 6).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Assets/Scripts/O3DE.Core/Interop/ScriptComponentBridge.cs Assets/Scripts/O3DE.Core.Tests/Interop/ScriptComponentBridgeTests.cs
+git commit -m "SP-1a: managed bridge with handle table and [UnmanagedCallersOnly] entry
+
+A pinned thunk must target a static method, but lifecycle callbacks are per
+instance, so C++ holds an opaque int handle per component and passes it back on
+every call; the managed side resolves it via a dictionary rather than
+reflection. Handle 0 is reserved as the native no-handle sentinel.
+
+Invoke never throws - an exception crossing an [UnmanagedCallersOnly] boundary
+terminates the process - and returns 0 for a dead handle so a teardown racing an
+in-flight tick is safe."
+```
+
+---
+
+### Task 4: Route `Tick` through the thunk, with fallback
+
+**Files:**
+- Modify: `Code/Source/Scripting/CSharpScriptComponent.h`
+- Modify: `Code/Source/Scripting/CSharpScriptComponent.cpp`
+
+**Interfaces:**
+- Consumes: `CoralNativeThunkHost::Get` (Task 2), `ScriptComponentBridge.Invoke` + `LifecycleId` (Task 3).
+
+> `Tick` is the highest-value target: `SafeInvokeMethod("Tick", deltaTime)` runs **every frame, per component**. Convert it first and in isolation, so the differential test in Task 5 has one well-understood change to validate.
+
+- [ ] **Step 1: Read the current implementation**
+
+Read `Code/Source/Scripting/CSharpScriptComponent.cpp` around lines 295-380 — `Activate`/`Deactivate`, the tick handler calling `SafeInvokeMethod("Tick", deltaTime)`, and both `SafeInvokeMethod` overloads. Note exactly how `m_scriptInstance` is created and destroyed; the handle must be registered and unregistered on the same boundaries.
+
+- [ ] **Step 2: Add the thunk members to the header**
+
+In `CSharpScriptComponent.h`, in the private section:
+
+```cpp
+        //! Signature of ScriptComponentBridge.Invoke (see O3DE.Core's
+        //! Interop/ScriptComponentBridge.cs). Returns 1 if dispatched, 0 if
+        //! the handle was dead. Must match that method exactly.
+        using BridgeInvokeFn = int (*)(int handle, int lifecycleId, float arg);
+
+        //! Native handle for this component's managed instance, obtained from
+        //! ScriptComponentBridge.Register. 0 means "not registered".
+        int m_bridgeHandle = 0;
+
+        //! Resolved once; nullptr means "no thunk available, use InvokeMethod".
+        BridgeInvokeFn m_bridgeInvoke = nullptr;
+
+        //! Lifecycle ids - must match O3DE.Interop.LifecycleId exactly.
+        enum class LifecycleId : int
+        {
+            OnCreate = 1,
+            OnDestroy = 2,
+            Tick = 3,
+            OnTransformChanged = 4,
+        };
+
+        //! Try the pinned-thunk path. Returns false if unavailable, in which
+        //! case the caller MUST fall back to SafeInvokeMethod.
+        bool TryInvokeViaThunk(LifecycleId id, float arg) noexcept;
+```
+
+- [ ] **Step 3: Implement the thunk path**
+
+In `CSharpScriptComponent.cpp`, add:
+
+```cpp
+    bool CSharpScriptComponent::TryInvokeViaThunk(LifecycleId id, float arg) noexcept
+    {
+        if (m_bridgeInvoke == nullptr || m_bridgeHandle == 0)
+        {
+            return false;
+        }
+
+        // A 0 return means the managed handle is dead (component torn down).
+        // That is NOT a reason to fall back to InvokeMethod - the instance is
+        // gone, so doing nothing is correct.
+        m_bridgeInvoke(m_bridgeHandle, static_cast<int>(id), arg);
+        return true;
+    }
+```
+
+- [ ] **Step 4: Route Tick through it**
+
+Replace the tick call site's `SafeInvokeMethod("Tick", deltaTime);` with:
+
+```cpp
+            // Fast path: a resolved pinned thunk costs an indirect call plus a
+            // dictionary lookup. InvokeMethod would do a managed-side string
+            // lookup plus reflection dispatch - every frame, per component.
+            if (!TryInvokeViaThunk(LifecycleId::Tick, deltaTime))
+            {
+                SafeInvokeMethod("Tick", deltaTime);
+            }
+```
+
+- [ ] **Step 5: Resolve the thunk and register the handle**
+
+Where `m_scriptInstance` is created (after it is valid), resolve the thunk and register the handle. Use the real accessor for the host that the surrounding code already uses — read the file rather than assuming:
+
+```cpp
+        // Resolve the pinned thunk once per instance. Failure is expected and
+        // survivable: m_bridgeInvoke stays null and every call site falls back.
+        m_bridgeInvoke = reinterpret_cast<BridgeInvokeFn>(
+            thunkHost.Get("O3DE.Interop.ScriptComponentBridge, O3DE.Core", "Invoke"));
+
+        // One-shot, so InvokeMethod's cost is irrelevant here. Uses the same
+        // value-returning pattern already proven in the codebase (see
+        // O3DESharpSystemComponent.cpp: InvokeMethod<Coral::String>(...)).
+        m_bridgeHandle = m_scriptInstance.InvokeMethod<int>("AcquireBridgeHandle");
+```
+
+This immediately follows `m_scriptInstance = hostManager->CreateInstance(*m_scriptType);` (around `CSharpScriptComponent.cpp:578`) — the instance must exist before either call.
+
+- [ ] **Step 6: Add the managed handle accessors**
+
+`ScriptComponentBridge.Register` is `static`, and the proven native call path in this codebase is the **instance** method `InvokeMethod<T>`. So `ScriptComponent` needs two thin instance methods that native can call. Add to `Assets/Scripts/O3DE.Core/ScriptComponent.cs`:
+
+```csharp
+        // Native bridge handle. Assigned on first acquire; 0 means unregistered.
+        private int _bridgeHandle;
+
+        /// <summary>
+        /// Register this instance with <see cref="O3DE.Interop.ScriptComponentBridge"/>
+        /// and return its native handle. Called once by native code immediately
+        /// after construction. Idempotent - repeated calls return the same handle.
+        /// </summary>
+        public int AcquireBridgeHandle()
+        {
+            if (_bridgeHandle == 0)
+            {
+                _bridgeHandle = O3DE.Interop.ScriptComponentBridge.Register(this);
+            }
+            return _bridgeHandle;
+        }
+
+        /// <summary>
+        /// Release the native bridge handle. Called by native code during
+        /// teardown, AFTER the final OnDestroy dispatch. Safe to call twice.
+        /// </summary>
+        public void ReleaseBridgeHandle()
+        {
+            if (_bridgeHandle != 0)
+            {
+                O3DE.Interop.ScriptComponentBridge.Unregister(_bridgeHandle);
+                _bridgeHandle = 0;
+            }
+        }
+```
+
+Then in `Deactivate`/destruction, unregister symmetrically and clear the native members. **Order matters** — this must run *after* the `OnDestroy` dispatch (see Task 7 Step 2):
+
+```cpp
+        if (m_bridgeHandle != 0)
+        {
+            m_scriptInstance.InvokeMethod("ReleaseBridgeHandle");
+            m_bridgeHandle = 0;
+        }
+        m_bridgeInvoke = nullptr;
+```
+
+- [ ] **Step 7: Structural verification**
+
+```bash
+python -c "
+import pathlib
+h = pathlib.Path('Code/Source/Scripting/CSharpScriptComponent.h').read_text(encoding='utf-8')
+c = pathlib.Path('Code/Source/Scripting/CSharpScriptComponent.cpp').read_text(encoding='utf-8')
+assert 'TryInvokeViaThunk' in h and 'TryInvokeViaThunk' in c
+assert 'SafeInvokeMethod(\"Tick\"' in c, 'the InvokeMethod fallback must remain'
+assert 'if (!TryInvokeViaThunk' in c, 'Tick must attempt the thunk first'
+print('structural checks pass')
+"
+```
+Expected: `structural checks pass` — note it asserts the fallback still exists.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Code/Source/Scripting/CSharpScriptComponent.h Code/Source/Scripting/CSharpScriptComponent.cpp
+git commit -m "SP-1a: route CSharpScriptComponent::Tick through a pinned thunk
+
+Tick ran SafeInvokeMethod(\"Tick\", dt) every frame per component, and
+ManagedObject::InvokeMethod does a managed-side string lookup plus reflection
+dispatch on every call. It now attempts a resolved pinned thunk first and falls
+back to InvokeMethod when one is unavailable, so a resolution failure costs
+speed rather than correctness.
+
+Only Tick is converted here; the remaining lifecycle calls follow once the
+differential test covers this path.
+
+NOT COMPILE-VERIFIED: no O3DE engine SDK in the authoring environment."
+```
+
+---
+
+### Task 5: Differential + fallback tests
+
+**Files:**
+- Modify: `Assets/Scripts/O3DE.Core.Tests/Interop/ScriptComponentBridgeTests.cs`
+
+> Full native↔managed differential testing needs a live host and is the maintainer's engine-side verification (Task 6). What **is** testable here is the managed half of the contract: that `Dispatch` routes each `LifecycleId` to the right callback, and that the native ABI constants have not drifted.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Assets/Scripts/O3DE.Core.Tests/Interop/ScriptComponentBridgeTests.cs`:
+
+```csharp
+/// <summary>
+/// Pins the native ABI. LifecycleId values are passed as raw integers from
+/// CSharpScriptComponent.cpp's enum of the same name; if these drift apart,
+/// Tick starts calling OnDestroy and nothing fails to compile on either side.
+/// </summary>
+public class LifecycleIdAbiTests
+{
+    [Theory]
+    [InlineData(LifecycleId.OnCreate, 1)]
+    [InlineData(LifecycleId.OnDestroy, 2)]
+    [InlineData(LifecycleId.Tick, 3)]
+    [InlineData(LifecycleId.OnTransformChanged, 4)]
+    public void LifecycleId_HasStableNativeValue(LifecycleId id, int expected)
+    {
+        ((int)id).Should().Be(expected,
+            "these integers are the native ABI - renumbering silently misroutes callbacks");
+    }
+
+    [Fact]
+    public void Dispatch_UnknownLifecycleId_ReturnsFalse()
+    {
+        var component = new DispatchProbe();
+        ScriptComponentBridge.Dispatch(component, (LifecycleId)9999, 0f).Should().BeFalse();
+        component.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Dispatch_NonScriptComponent_ReturnsFalse()
+    {
+        ScriptComponentBridge.Dispatch(new object(), LifecycleId.Tick, 0f).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Dispatch_RoutesTickWithDeltaTime()
+    {
+        var component = new DispatchProbe();
+
+        ScriptComponentBridge.Dispatch(component, LifecycleId.Tick, 0.25f).Should().BeTrue();
+
+        component.Calls.Should().ContainSingle().Which.Should().Be("Tick:0.25");
+    }
+
+    [Theory]
+    [InlineData(LifecycleId.OnCreate, "OnCreate")]
+    [InlineData(LifecycleId.OnDestroy, "OnDestroy")]
+    [InlineData(LifecycleId.OnTransformChanged, "OnTransformChanged")]
+    public void Dispatch_RoutesEachLifecycleToItsCallback(LifecycleId id, string expected)
+    {
+        var component = new DispatchProbe();
+
+        ScriptComponentBridge.Dispatch(component, id, 0f).Should().BeTrue();
+
+        component.Calls.Should().ContainSingle().Which.Should().Be(expected);
+    }
+}
+```
+
+- [ ] **Step 2: Add the probe type**
+
+The probe must derive from the real `ScriptComponent` so `Dispatch`'s type check is genuinely exercised. Append to the same test file, adjusting the overrides to match `ScriptComponent`'s actual virtual members (read it first):
+
+```csharp
+/// <summary>
+/// Records which callbacks fired, so routing can be asserted.
+///
+/// NOTE: overrides OnUpdate, NOT Tick. In ScriptComponent, `Tick(float)` is a
+/// public NON-virtual method (the native entry point, which also drives the
+/// Invoke/InvokeRepeating timer machinery) and it calls the virtual
+/// `OnUpdate(float)`. Attempting `override void Tick` does not compile.
+/// Dispatching LifecycleId.Tick therefore surfaces here as an OnUpdate call.
+/// </summary>
+internal sealed class DispatchProbe : ScriptComponent
+{
+    public List<string> Calls { get; } = new List<string>();
+
+    public override void OnCreate() => Calls.Add("OnCreate");
+    public override void OnDestroy() => Calls.Add("OnDestroy");
+    public override void OnUpdate(float deltaTime) =>
+        Calls.Add($"Tick:{deltaTime.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+    public override void OnTransformChanged() => Calls.Add("OnTransformChanged");
+}
+```
+
+- [ ] **Step 3: Run to verify they fail, then pass**
+
+Run: `dotnet test Assets/Scripts/O3DE.Core.Tests/O3DE.Core.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~Interop"`
+Expected: initially failures (missing `DispatchProbe` / accessibility); after Step 2 and any signature reconciliation, all pass.
+
+- [ ] **Step 4: Run the full managed suite**
+
+Run: `dotnet test Assets/Scripts/O3DE.Core.Tests/O3DE.Core.Tests.csproj -c Release --nologo`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Assets/Scripts/O3DE.Core.Tests/Interop/ScriptComponentBridgeTests.cs
+git commit -m "SP-1a: pin the lifecycle ABI and dispatch routing
+
+LifecycleId integers are the native ABI - CSharpScriptComponent.cpp declares a
+matching enum and passes raw ints. If the two drift, Tick starts invoking
+OnDestroy and nothing fails to compile on either side, so the values are now
+asserted explicitly alongside routing tests for every callback."
+```
+
+---
+
+### Task 6: Engine-side verification — **MAINTAINER-EXECUTED**
+
+**Files:** none.
+
+> Requires a real O3DE engine build. None of the C++ in Tasks 2 and 4 has been compiled.
+
+- [ ] **Step 1: Build with the updated Coral fork**
+
+Reconfigure so FetchContent picks up the Coral commit from Task 1, and build the gem.
+Expected: builds clean. Compilation errors in `CoralNativeThunkHost` or `CSharpScriptComponent` are expected fallout of authoring C++ blind — fix and report them.
+
+- [ ] **Step 2: Verify the thunk actually resolves**
+
+Run the Editor with a C# script component on an entity. Confirm the log does **not** contain
+`No pinned thunk for O3DE.Interop.ScriptComponentBridge, O3DE.Core::Invoke`.
+If it does, the thunk is not resolving and every call is silently falling back — functional, but the task delivered nothing.
+
+- [ ] **Step 3: Differential check**
+
+Confirm behaviour is unchanged: `OnCreate`, `Tick`, `OnTransformChanged` and `OnDestroy` all still fire, in order, with correct `deltaTime`. Then deliberately force the fallback (e.g. temporarily rename the managed method so resolution fails) and confirm behaviour is **identical** via `InvokeMethod`. Both paths must be indistinguishable.
+
+- [ ] **Step 4: Measure**
+
+Capture a before/after profile of the per-frame tick cost with a meaningful number of C# components (100+). The expected win is the removal of a managed string lookup plus reflection dispatch per component per frame. Record the number — it justifies (or refutes) proceeding to Task 7 and Half B.
+
+- [ ] **Step 5: Report**
+
+Report build fixes, whether the thunk resolved, differential result, and the measurement.
+
+---
+
+### Task 7: Convert the remaining lifecycle calls
+
+**Files:**
+- Modify: `Code/Source/Scripting/CSharpScriptComponent.cpp`
+
+> **Gated on Task 6.** Do not convert the rest until `Tick` is proven working and measured in a real build.
+
+- [ ] **Step 1: Convert the remaining three call sites**
+
+Apply the same pattern to `OnCreate`, `OnDestroy` and `OnTransformChanged`:
+
+```cpp
+            if (!TryInvokeViaThunk(LifecycleId::OnCreate, 0.0f))
+            {
+                SafeInvokeMethod("OnCreate");
+            }
+```
+
+```cpp
+        if (!TryInvokeViaThunk(LifecycleId::OnDestroy, 0.0f))
+        {
+            SafeInvokeMethod("OnDestroy");
+        }
+```
+
+```cpp
+            if (!TryInvokeViaThunk(LifecycleId::OnTransformChanged, 0.0f))
+            {
+                SafeInvokeMethod("OnTransformChanged");
+            }
+```
+
+Leave `ApplyExposedProperties` and `GetExposedPropertySchemaJson` on `InvokeMethod`: they are one-shot editor-path calls that pass strings, so they gain nothing and would need a different ABI.
+
+- [ ] **Step 2: Ordering check for OnDestroy**
+
+`OnDestroy` runs during teardown. Confirm the bridge handle is still registered at that point and only unregistered **after** the `OnDestroy` dispatch — otherwise the thunk sees a dead handle, returns 0, and `OnDestroy` is silently skipped. This is the one ordering hazard in the conversion.
+
+- [ ] **Step 3: Structural verification**
+
+```bash
+python -c "
+import pathlib
+c = pathlib.Path('Code/Source/Scripting/CSharpScriptComponent.cpp').read_text(encoding='utf-8')
+for lid in ('OnCreate','OnDestroy','Tick','OnTransformChanged'):
+    assert f'LifecycleId::{lid}' in c, lid
+    assert f'SafeInvokeMethod(\"{lid}\"' in c, f'{lid} fallback must remain'
+print('all four lifecycle calls converted, all fallbacks retained')
+"
+```
+Expected: `all four lifecycle calls converted, all fallbacks retained`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Code/Source/Scripting/CSharpScriptComponent.cpp
+git commit -m "SP-1a: route remaining lifecycle calls through pinned thunks
+
+OnCreate, OnDestroy and OnTransformChanged now follow the same
+try-thunk-then-fall-back pattern as Tick. ApplyExposedProperties and
+GetExposedPropertySchemaJson deliberately stay on InvokeMethod: one-shot
+editor-path calls passing strings, which would need a different ABI for no gain.
+
+OnDestroy required care - the bridge handle must outlive the dispatch, or the
+thunk sees a dead handle and the callback is silently skipped.
+
+NOT COMPILE-VERIFIED: no O3DE engine SDK in the authoring environment."
+```
+
+---
+
+## What is NOT in this plan
+
+Half B — `NativeBindingManifest`, `ReflectionCallSiteParser`, `NativeBindingGenerator`, `BindingRegistry`, load-time manifest validation, and binding-coverage telemetry — is a separate plan, written after SP-1a lands. Half B is the larger, riskier half and is the piece dual-mode AOT consumes; it should not start until the thunk path is proven in a real build (Task 6).

--- a/docs/superpowers/specs/2026-07-15-sp1-marshaling-core-design.md
+++ b/docs/superpowers/specs/2026-07-15-sp1-marshaling-core-design.md
@@ -1,0 +1,206 @@
+# SP-1 — Marshaling Core — Design
+
+**Date:** 2026-07-15
+**Status:** Design accepted; ready for implementation planning.
+**Author:** Mikael K. Aboagye (WD Studios Corp.), via collaborative brainstorm 2026-07-15.
+**Parent program:** `docs/superpowers/specs/2026-07-15-first-class-csharp-program-design.md` (SP-1)
+**Starting point:** the rescued "1B" work on branch `feat/1b-native-trampoline-rescue` (`8a00627`),
+quarantined under `Rescued/1b-native-trampoline/` — 2,758 lines across 9 files.
+
+---
+
+## 1. Goal
+
+Build one correct, extensible dispatch layer between Coral and `AZ::BehaviorContext` that removes
+the per-call reflection overhead in **both** directions, and that doubles as the **static-dispatch
+foundation dual-mode AOT requires**.
+
+This is the v1.3 BehaviorContext refactor, pulled forward because SP-3 (native C# components),
+SP-8/SP-9 (C# editor tooling), and the AOT milestone all sit on it.
+
+## 2. Locked decisions
+
+| Decision | Choice |
+|---|---|
+| Scope | **Dispatch performance + AOT foundation only.** The deterministic sim-lane framing in the rescued comments is explicitly dropped. |
+| Coral access | **Add a proper public function-pointer API to the `WatchDogStudios/Coral` fork.** Delete the independent hostfxr re-initialization workaround. |
+| `native_symbol` source | **Accept the libclang coupling.** Generate the manifest and trampolines on Windows; **commit the artifacts** so Linux/CI consume them without libclang. |
+| Relationship to `GenericDispatcher` | **Additive fast paths.** `GenericDispatcher` / `BehaviorMethod::Call` remain the correctness baseline and universal fallback. Not a rewrite. |
+| Ordering | **Half A (native→managed thunks) first**, then Half B (managed→native trampolines). |
+
+## 3. Two verified constraints this design is built around
+
+Both were established by the rescued work and independently confirmed while reading it. They are
+facts about O3DE and Coral, not implementation choices, and the design is shaped by them.
+
+### 3.1 Coral's call directions are asymmetric
+
+The **managed→native** direction is already a zero-per-call pinned thunk: `AddInternalCall` plus
+`delegate* unmanaged<...>` fields (see `ScriptBindings.cpp` / `InternalCalls.cs`).
+
+The **native→managed** direction has exactly one path — `Coral::ManagedObject::InvokeMethod<T>(
+AZStd::string_view methodName, ...)` — which performs a managed-side **string lookup plus .NET
+reflection dispatch on every call**. No Coral API hands native code a raw function pointer into a
+managed method.
+
+The remedy is a standard .NET hosting primitive, not a Coral hack:
+`hostfxr_get_runtime_delegate(ctx, hdt_load_assembly_and_get_function_pointer, ...)` yields a
+`load_assembly_and_get_function_pointer_fn` which, given an assembly-qualified type name and an
+`[UnmanagedCallersOnly]` static method, returns a raw native-callable pointer with **zero managed
+lookup per call thereafter**. Coral's own `HostInstance` already uses exactly this to bootstrap
+`Coral.Managed`.
+
+### 3.2 `BehaviorContext` does not retain the native C++ symbol
+
+`AZ::BehaviorContext` / `BehaviorMethodImpl` stores **no** native symbol. The functor backing a
+reflected method captures a raw function pointer inside a type-erased `AZStd::function`; nothing in
+the runtime object exposes that pointer or the qualified C++ name that produced it. Only the
+reflected *script* name survives.
+
+Therefore `native_symbol` **can never** be recovered by walking a live `BehaviorContext`. It requires
+a second, independent, offline pass: a libclang parse of each gem's reflection `.cpp` extracting the
+`&C::Method` expression from `->Method("name", &C::Method)`, joined to the runtime data on
+`(className, reflected script-name)`.
+
+This is the sole reason Half B has an offline component at all.
+
+## 4. Architecture
+
+`GenericDispatcher` and `BehaviorMethod::Call` are **unchanged** and remain the correctness baseline.
+SP-1 adds two independent, opt-in fast paths, each of which degrades to that baseline.
+
+```
+                    ┌──────────────────────────────┐
+   native  ──────►  │  Half A: pinned thunks       │  ──────►  managed
+                    │  (Coral fork fn-ptr API)     │
+                    └──────────────────────────────┘
+                    ┌──────────────────────────────┐
+   managed ──────►  │  Half B: generated           │  ──────►  native
+                    │  trampolines + BindingRegistry│
+                    └──────────────┬───────────────┘
+                                   │ unresolved / rejected
+                                   ▼
+                    ┌──────────────────────────────┐
+                    │  BehaviorMethod::Call        │  (baseline, always correct)
+                    └──────────────────────────────┘
+```
+
+A gap in the fast path is therefore a **performance** regression, never a correctness bug. That
+property is load-bearing given `native_symbol` recovery is a heuristic join across two independent
+passes.
+
+## 5. Half A — native→managed pinned thunks
+
+**Lands first.** Smaller, self-contained, and unblocks SP-3.
+
+- **Coral fork (`WatchDogStudios/Coral`), cross-repo:** add a public function-pointer API — either
+  expose the existing private `HostInstance::LoadCoralManagedFunctionPtr`, or add a cleaner
+  `HostInstance::GetFunctionPointer(assemblyQualifiedTypeName, methodName)`. Prefer the latter: a
+  named, documented API rather than widening an internal.
+- **Gem:** rebuild `CoralNativeThunkHost` on that API and **delete the independent
+  `hostfxr_initialize_for_runtime_config` re-initialization entirely.** That workaround existed only
+  because an earlier task forbade touching anything outside `Gems/O3DESharp`; that constraint no
+  longer applies. Removing it also removes a subtle long-term reliance on
+  `Success_HostAlreadyInitialized` semantics for a second init against a running CLR.
+- **Managed:** `[UnmanagedCallersOnly]` static entry points in `O3DE.Core`, following the existing
+  `InternalCalls` blittable-argument convention.
+- **Unblocks:** SP-3 component lifecycle (`Activate` / `Deactivate` / `OnTick`) at pinned-thunk cost.
+
+## 6. Half B — managed→native trampolines
+
+Replaces `BehaviorMethod::Call`'s `virtual → AZStd::function → per-arg RTTI ConvertTo` path with a
+direct generated trampoline, for the conservatively-selected subset that can be bound safely.
+
+### 6.1 The manifest is built by two passes and joined offline
+
+1. **Runtime pass — C++, `NativeBindingManifest`.** Owns the runtime-observable half: owning class
+   type id / size / align, reflected name, per-argument `ArgStorageClass`
+   (`Value` / `Pointer` / `Reference` / `ConstReference` / `Unknown`), return type, arity.
+2. **Offline pass — `ReflectionCallSiteParser.cs`.** libclang over each gem's reflection `.cpp`,
+   recovering `&C::Method` per §3.2.
+3. **Join — `NativeBindingGenerator.cs`,** keyed on `(className, reflected script-name)`, emitting
+   the trampolines and the `BindingRegistry` table (stable binding-id string → function pointer,
+   e.g. `"Vector3::GetLength"`).
+
+This split is deliberate and preserved from the rescued design: `BehaviorContextReflector` answers
+"what got reflected"; this layer answers "of that, what can be bound natively, and to what symbol."
+Existing consumers (`GenericDispatcher`, `ReflectionDataExporter`) stay untouched.
+
+### 6.2 The v1 classifier is deliberately conservative
+
+A method is **not** bound when any of these hold (the existing `NonBindableReason` enum):
+`Overloaded`, `ReflectedViaLambda`, `OnDemandTemplateType`, `EBusAddressedById`,
+`UnresolvedNativeSymbol`, `UnsupportedArgStorage`, `NoNativeSideCounterpart`.
+
+Every one of these falls back to `BehaviorMethod::Call`. Widening the bound set is a later,
+evidence-driven change — not a v1 goal.
+
+### 6.3 Artifacts are generated on Windows and committed
+
+The libclang backend is win-x64-only and is not the default binding backend. Rather than block on
+making it cross-platform, the manifest and generated trampolines are produced by a **Windows-only
+build step and committed as artifacts**, so Linux and CI builds consume them with no libclang
+dependency. This is what makes §6.1's offline pass compatible with the Linux parity just shipped.
+
+## 7. Safety: load-time manifest validation is mandatory
+
+**This is the highest-risk element of the design and is not optional.**
+
+A committed artifact can go stale against an engine whose reflection changed. A stale entry means
+invoking a function pointer with a mismatched signature — **memory-unsafe**, not merely incorrect.
+
+Therefore, at load, every manifest entry is cross-checked against the **live `BehaviorContext`**:
+owning class type id, arity, per-argument type ids and storage classes, and return type. Any entry
+that does not match exactly is **rejected into the fallback path and logged loudly**. A rejected
+entry is a normal, survivable outcome; a silently trusted stale entry is not.
+
+The runtime-observable half of the manifest (§6.1 pass 1) exists precisely to make this check
+possible — it is not redundant with the offline half.
+
+## 8. Verification strategy
+
+| Concern | Method |
+|---|---|
+| Classifier correctness | Unit tests per `NonBindableReason`, on fixtures — each reason maps 1:1 to a check. |
+| Offline join correctness | Unit tests over reflection-`.cpp` fixtures, including deliberate mis-join bait (same script name on two classes; same C++ name reflected under a different script name). |
+| **Trampoline correctness** | **Differential testing** — invoke the same method through the trampoline and through `BehaviorMethod::Call`, assert identical results, across the whole bound surface. Generator unit tests alone cannot establish this. |
+| Stale-manifest safety | Tests that deliberately corrupt a manifest entry (wrong arity, wrong type id) and assert it is rejected into fallback, not called. |
+| **Silent degradation** | **Binding-coverage telemetry** — record and assert the bound fraction in CI, so a regression that quietly drops everything to the slow path fails the build instead of being noticed months later. |
+| Half A correctness | Round-trip tests through pinned thunks; verify no per-call managed allocation/lookup remains. |
+
+## 9. Risks
+
+1. **The `(className, script-name)` join is heuristic.** Mis-joins are possible in principle.
+   Mitigated by §7 load-time validation (a mis-join almost always produces a signature mismatch) and
+   by §8's mis-join bait tests.
+2. **Manifest staleness.** Mitigated by §7 — the mandatory mitigation, not a nice-to-have.
+3. **Dual-path drift.** Two dispatch paths can diverge in behaviour over time. Mitigated by §8's
+   differential testing being run over the full bound surface, not a sample.
+4. **Cross-repo dependency.** Half A needs the Coral fork API landed; the gem side cannot be
+   completed until it is. Sequence them together.
+5. **Coverage collapse.** An engine reflection change could silently drop the bound fraction toward
+   zero. Mitigated by §8's coverage telemetry.
+
+## 10. Non-goals
+
+- **Determinism / deterministic sim lane.** Explicitly dropped. The rescued code's references to
+  `ISimSystem` / `SimSystemBase` / tiering-lock are historical context; that second half was never
+  written and is not in scope.
+- **Replacing `GenericDispatcher`.** It remains the baseline. A future consolidation is a separate
+  decision.
+- **Widening the bound set beyond the conservative v1 classifier.**
+- **Making the libclang pass cross-platform** (deferred; §6.3 sidesteps it).
+- **SP-3 component work, AOT publishing, consoles/Mono.**
+
+## 11. Open questions
+
+1. **The missing "1B spec".** The rescued sources cite a *"1B spec §3 point 3 / §6.3"* containing the
+   original verified analysis. It does not exist in either repo. If recoverable, it should be added —
+   it may contain manifest-schema decisions this design would otherwise rediscover. Not a blocker.
+2. **Exact Coral API shape.** Whether to expose `LoadCoralManagedFunctionPtr` or add
+   `GetFunctionPointer` is settled at implementation time against the fork's actual `HostInstance`
+   surface; this design prefers the latter but does not mandate the signature.
+3. **How much of the rescued code survives verbatim.** The rescued files are unfinished and have
+   never been compiled. The implementation plan must budget for the possibility that parts are
+   rewritten rather than integrated; the rescue preserved *intent and analysis*, which is the durable
+   value, not necessarily the exact lines.


### PR DESCRIPTION
Implements the **managed half** of [the SP-1a plan](docs/superpowers/plans/2026-07-15-sp1a-native-managed-thunks.md) (Tasks 3 and 5), per [the SP-1 spec](docs/superpowers/specs/2026-07-15-sp1-marshaling-core-design.md). Both design docs are included here — they were previously only on a local disk.

## Why

`Coral::ManagedObject::InvokeMethod` — Coral's **only** native→managed call path — performs a managed-side string lookup plus .NET reflection dispatch on *every* call. `CSharpScriptComponent` calls `SafeInvokeMethod("Tick", dt)` **every frame, per component**.

The fix resolves an `[UnmanagedCallersOnly]` static to a raw function pointer once. Because that target must be **static** while lifecycle callbacks are **per-instance**, native code holds an opaque `int` handle per component and passes it back — which is what this PR builds.

## What's here

- **`O3DE.Interop.ScriptComponentBridge`** — handle table (`Register`/`Unregister`/`Resolve`), the `[UnmanagedCallersOnly] Invoke` entry point, and `Dispatch` routing. Handle `0` is reserved as the native "no handle" sentinel; `Invoke` never throws, because an exception crossing that boundary terminates the process.
- **`ScriptComponent.AcquireBridgeHandle()` / `ReleaseBridgeHandle()`** — idempotent, called once per component via the value-returning `InvokeMethod<int>` pattern already proven in `O3DESharpSystemComponent.cpp`.
- **16 tests** covering the handle table (including that resolving a *dead* handle is safe — native teardown can race an in-flight tick) and pinning the `LifecycleId` native ABI.

## The subtlety worth reviewing

`ScriptComponent` has **both** `OnUpdate(float)` (`public virtual`) and `Tick(float)` (`public`, **non-virtual**). `Tick` is the native entry point and drives the `Invoke`/`InvokeRepeating` scheduler *plus* `OnUpdate`.

So `Dispatch` calls **`Tick`** — routing to `OnUpdate` directly would silently skip timer bookkeeping — while test probes override **`OnUpdate`**, since `override void Tick` doesn't compile. `LifecycleIdAbiTests` pins the integer values because C++ declares a matching enum and passes raw ints; if they drift, `Tick` starts invoking `OnDestroy` and *nothing fails to compile on either side*.

## Not in this PR

The C++ half (Tasks 2, 4, 7) and the cross-repo Coral change (Task 1: `HostInstance::GetFunctionPointer`) are not here. **Task 1 gates them**, and no C++ can be compile-verified without an O3DE engine SDK. Task 6 (engine-side verification) is maintainer-executed.

This PR is therefore inert at runtime — nothing calls the bridge yet. It's the foundation the C++ side will consume.

## Testing

- C# suite: **61 passed** (45 baseline + 16 new), 0 failed
- Python suite: **102 passed**, 0 failed

Also adds a `public Transform(ulong entityId)` ctor to the test `TransformStub` — `ScriptComponent`'s `Transform` property needs the overload only the real `Transform.cs` had, which surfaced once `ScriptComponent.cs` was linked into the test project.