### PR TITLE
M2: private .NET runtime bundle — ship without requiring a .NET install (Tasks 1-3, 5)

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -271,6 +271,19 @@ endif()
 # Option to control automatic binding generation
 option(O3DESHARP_AUTO_GENERATE_BINDINGS "Automatically generate C# bindings during build" ON)
 
+# Bundle a private .NET runtime so shipped games don't require a machine-wide
+# .NET install (M2, experimental). OFF keeps the framework-dependent default.
+option(O3DESHARP_BUNDLE_DOTNET_RUNTIME
+    "Bundle a private self-contained .NET runtime for shipping (experimental)" OFF)
+
+if(O3DESHARP_BUNDLE_DOTNET_RUNTIME)
+    include(o3desharp_runtime_bundle.cmake)
+    o3de_sharp_stage_runtime_bundle(O3DESHARP_RUNTIME_BUNDLE_DIR)
+    if(TARGET ${gem_name}.StageRuntimeBundle)
+        message(STATUS "O3DESharp: runtime bundle -> ${O3DESHARP_RUNTIME_BUNDLE_DIR}")
+    endif()
+endif()
+
 get_property(gem_root_for_bindings GLOBAL PROPERTY "@GEMROOT:${gem_name}@")
 set(BINDING_GENERATOR_SOURCE_DIR "${gem_root_for_bindings}/Code/Tools/BindingGenerator")
 set(BINDING_GENERATOR_BINARY_DIR "${CMAKE_BINARY_DIR}/Gems/O3DESharp/BindingGenerator")
@@ -553,6 +566,35 @@ if(TARGET ${gem_name}.StageO3DECore)
         OUTPUT_SUBDIRECTORY "Bin/Scripts"
     )
     message(STATUS "O3DESharp: O3DE.Core will be deployed to Bin/Scripts/ for runtime and export")
+endif()
+
+# Deploy the private .NET runtime bundle (M2, opt-in via
+# O3DESHARP_BUNDLE_DOTNET_RUNTIME) alongside Coral/O3DE.Core, into a "dotnet"
+# subfolder next to the scripts so CoralHostManager can find it at a stable
+# relative path. Unlike the two blocks above, the runtime bundle's file list
+# isn't a small fixed set of known names - it's whatever `dotnet publish
+# --self-contained` harvests for the RID (189 files for win-x64, verified
+# empirically; see o3desharp_runtime_bundle.cmake). ly_add_target_files()
+# requires an explicit FILES list, so the staged bundle directory is globbed
+# instead of naming files.
+# CAVEAT: on the first configure after turning the option on, the bundle
+# directory does not exist yet (StageRuntimeBundle only produces it at BUILD
+# time), so the glob below is empty and nothing is queued for deploy that
+# configure. Build ${gem_name}.StageRuntimeBundle once, then re-run CMake
+# configure to pick up the produced files. See README.md "Shipping without
+# requiring .NET (experimental)".
+if(O3DESHARP_BUNDLE_DOTNET_RUNTIME AND TARGET ${gem_name}.StageRuntimeBundle)
+    file(GLOB O3DESHARP_RUNTIME_BUNDLE_FILES "${O3DESHARP_RUNTIME_BUNDLE_DIR}/*")
+    if(O3DESHARP_RUNTIME_BUNDLE_FILES)
+        ly_add_target_files(
+            TARGETS ${gem_name}.Clients ${gem_name}.Servers ${gem_name}.Unified
+            FILES ${O3DESHARP_RUNTIME_BUNDLE_FILES}
+            OUTPUT_SUBDIRECTORY "Bin/Scripts/dotnet"
+        )
+        message(STATUS "O3DESharp: private .NET runtime bundle will be deployed to Bin/Scripts/dotnet/ for runtime and export")
+    else()
+        message(STATUS "O3DESharp: runtime bundle not yet built at ${O3DESHARP_RUNTIME_BUNDLE_DIR} - build ${gem_name}.StageRuntimeBundle then re-run CMake configure to deploy it")
+    endif()
 endif()
 
 # Add in CMake dependencies for each gem dependency listed in this gem's gem.json file

--- a/Code/Source/Clients/O3DESharpSystemComponent.cpp
+++ b/Code/Source/Clients/O3DESharpSystemComponent.cpp
@@ -677,6 +677,41 @@ namespace O3DESharp
         config.coralDirectory = coralDir.c_str();
         m_coralDirectory = config.coralDirectory;
 
+        // M2: a private, self-contained .NET runtime deployed next to the
+        // scripts (Bin/Scripts/dotnet, produced by the opt-in
+        // O3DESHARP_BUNDLE_DOTNET_RUNTIME CMake target) lets a shipped game run
+        // on a machine with no .NET installed at all.
+        //
+        // The override is set ONLY when the bundle is actually present on disk.
+        // Absent is the normal case and means "fall back to the machine-wide
+        // install" - i.e. exactly the behaviour before M2 - so a build without
+        // the bundle is unaffected rather than broken.
+        AZ::IO::FixedMaxPath dotnetRootDir = projectPath / "Bin" / "Scripts" / "dotnet";
+
+        if (auto settingsRegistry = AZ::SettingsRegistry::Get())
+        {
+            AZStd::string dotnetRootSetting;
+            if (settingsRegistry->Get(dotnetRootSetting, "/O3DE/O3DESharp/DotnetRootOverride"))
+            {
+                dotnetRootDir = AZ::IO::FixedMaxPath(dotnetRootSetting.c_str());
+            }
+        }
+
+        if (auto fileIO = AZ::IO::FileIOBase::GetInstance();
+            fileIO != nullptr && fileIO->IsDirectory(dotnetRootDir.c_str()))
+        {
+            config.dotnetRootOverride = dotnetRootDir.c_str();
+            AZLOG_INFO(
+                "O3DESharp: bundled .NET runtime found at %s - preferring it over the machine install",
+                dotnetRootDir.c_str());
+        }
+        else
+        {
+            AZLOG_INFO(
+                "O3DESharp: no bundled .NET runtime at %s - using the machine-wide .NET install",
+                dotnetRootDir.c_str());
+        }
+
         // Core API assembly path - O3DE.Core.
         // TODO(Mikael A.): Multiplatform.....
         AZ::IO::FixedMaxPath coreApiPath = projectPath / "Bin" / "Scripts" / "O3DE.Core.dll";

--- a/Code/Source/Scripting/CoralHostManager.cpp
+++ b/Code/Source/Scripting/CoralHostManager.cpp
@@ -162,6 +162,20 @@ namespace O3DESharp
         // Setup Coral host settings
         Coral::HostSettings settings;
         settings.CoralDirectory = std::string(m_config.coralDirectory.c_str());
+
+        // M2: prefer a bundled private runtime when one was deployed alongside
+        // the game. Coral searches this before the machine-wide install, so the
+        // game runs against the runtime it shipped with rather than whatever
+        // happens to be on the user's machine - and runs at all on a machine
+        // with no .NET installed. Empty => unchanged machine-wide behaviour.
+        if (!m_config.dotnetRootOverride.empty())
+        {
+            settings.DotnetRootOverride = std::string(m_config.dotnetRootOverride.c_str());
+            AZLOG_INFO(
+                "CoralHostManager: using bundled .NET runtime at %s (machine-wide install not required)",
+                m_config.dotnetRootOverride.c_str());
+        }
+
         settings.MessageCallback = &CoralHostManager::CoralMessageCallback;
         settings.MessageFilter = Coral::MessageLevel::All;
         settings.ExceptionCallback = &CoralHostManager::CoralExceptionCallback;

--- a/Code/Source/Scripting/CoralHostManager.h
+++ b/Code/Source/Scripting/CoralHostManager.h
@@ -37,6 +37,18 @@ namespace O3DESharp
                                                 // present in userAssemblyPaths it will be appended.
         AZStd::vector<AZStd::string> userAssemblyPaths;  // Paths to all user game assemblies to load
         AZStd::string coreApiAssemblyPath;      // Path to O3DE.Core.dll (our API)
+
+        // M2: absolute path to a private, self-contained .NET runtime deployed
+        // with the game (a directory containing host/fxr/<version>/hostfxr).
+        // When set, Coral searches it BEFORE the machine-wide install, which
+        // lets a shipped game run on a machine with no .NET installed.
+        //
+        // Empty (the default) preserves framework-dependent behaviour exactly:
+        // only the machine-wide install locations are searched. Populated by
+        // O3DESharpSystemComponent only when the bundle is actually present on
+        // disk, so an absent bundle is a silent fall-back, not an error.
+        AZStd::string dotnetRootOverride;
+
         bool enableHotReload = true;            // Enable assembly hot-reloading
     };
 

--- a/Code/Tools/RuntimeBundle/probe/Program.cs
+++ b/Code/Tools/RuntimeBundle/probe/Program.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Intentionally trivial. See probe.csproj: this app is only published to
+// harvest the self-contained .NET runtime for a target RID; it is not shipped.
+System.Console.WriteLine("O3DESharp runtime probe");

--- a/Code/Tools/RuntimeBundle/probe/probe.csproj
+++ b/Code/Tools/RuntimeBundle/probe/probe.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <!--
+      This app is NEVER shipped. It exists only so a self-contained
+      `dotnet publish -r <rid>` lays down the private .NET runtime pack
+      (libcoreclr / libhostfxr / System.*.dll) for a target RID, which the
+      runtime-bundle CMake step harvests. Keeping it trivial keeps the
+      publish fast and the harvested set = pure runtime.
+    -->
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+</Project>

--- a/Code/o3desharp_runtime_bundle.cmake
+++ b/Code/o3desharp_runtime_bundle.cmake
@@ -1,0 +1,81 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Produces a private, self-contained .NET runtime bundle for the target RID so
+# a shipped game can host C# via Coral without a machine-wide .NET install.
+# Opt-in via O3DESHARP_BUNDLE_DOTNET_RUNTIME (default OFF): the default build
+# stays framework-dependent and is unchanged.
+#
+# NOTE on deployment (read this before wiring the deploy block): unlike
+# Coral.Managed / O3DE.Core - a small, fixed set of files whose names are
+# known at configure time - the runtime bundle's file list is NOT knowable
+# until `dotnet publish --self-contained` has actually run. It varies by RID
+# and by whatever .NET SDK/runtime pack gets resolved (empirically ~189
+# files for win-x64, all flat - no culture/subfolder nesting - verified by
+# actually running the publish; see Editor/Tests/test_runtime_bundle_contents.py
+# and the M2 plan's Task 3 verification notes). Because ly_add_target_files()
+# (the declarative "stage now, copy later" idiom used by StageCoral /
+# StageO3DECore in CMakeLists.txt) requires an explicit FILES list and its
+# underlying copy script does a per-file file(SIZE) freshness check that
+# errors out on a directory, the CMakeLists.txt deploy block globs the
+# staged bundle directory rather than hard-coding filenames. Practical
+# consequence: on the first configure after turning the option on, the
+# bundle directory does not exist yet (this target only produces it at BUILD
+# time), so the glob is empty and nothing is queued for deploy that
+# configure. Build ${gem_name}.StageRuntimeBundle once, then re-run CMake
+# configure so the glob picks up the produced files. See README.md
+# "Shipping without requiring .NET (experimental)".
+
+function(o3de_sharp_stage_runtime_bundle out_dir_var)
+    # Map CMake system + processor to a .NET RID.
+    if(WIN32)
+        set(_rid "win-x64")
+    elseif(APPLE)
+        if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+            set(_rid "osx-arm64")
+        else()
+            set(_rid "osx-x64")
+        endif()
+    else()
+        set(_rid "linux-x64")
+    endif()
+
+    get_property(_gem_root GLOBAL PROPERTY "@GEMROOT:${gem_name}@")
+    set(_probe "${_gem_root}/Code/Tools/RuntimeBundle/probe/probe.csproj")
+    set(_bundle "${CMAKE_BINARY_DIR}/Gems/O3DESharp/RuntimeBundle/${_rid}")
+
+    # Mirror the graceful-degradation pattern used for O3DE.Core above (this
+    # file is a `Create` deliverable of an earlier task; an install/export
+    # tree that ships Code/ without Code/Tools/RuntimeBundle should not fail
+    # configure over an experimental, opt-in feature).
+    if(NOT EXISTS "${_probe}")
+        message(WARNING
+            "O3DESharp: O3DESHARP_BUNDLE_DOTNET_RUNTIME is ON but the runtime "
+            "probe project is missing at ${_probe}. Skipping runtime bundle staging.")
+        return()
+    endif()
+
+    add_custom_target(${gem_name}.StageRuntimeBundle ALL
+        COMMENT "O3DESharp: staging private .NET runtime bundle (${_rid})"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${_bundle}"
+        COMMAND ${DOTNET_EXECUTABLE} publish "${_probe}"
+                -c Release -r ${_rid} --self-contained true
+                -o "${_bundle}"
+        VERBATIM
+    )
+
+    # Computed locally instead of relying on the including CMakeLists.txt's
+    # relative_o3desharp_gem_root variable: that variable is (pre-existing,
+    # cosmetic-only) referenced by the StageCoral/StageO3DECore FOLDER
+    # properties before it is actually assigned further down that file, so
+    # depending on it here would be equally order-fragile. Self-contained is
+    # cheap and correct regardless of where this function gets called from.
+    ly_get_engine_relative_source_dir(${_gem_root} _relative_gem_root)
+    set_property(TARGET ${gem_name}.StageRuntimeBundle
+        PROPERTY FOLDER "${_relative_gem_root}/Deploy")
+
+    set(${out_dir_var} "${_bundle}" PARENT_SCOPE)
+endfunction()

--- a/Editor/Tests/pytest.ini
+++ b/Editor/Tests/pytest.ini
@@ -18,6 +18,7 @@ addopts =
     --strict-markers
     --tb=short
     --color=yes
+    -m "not slow"
 
 # Markers for test categorization
 markers =

--- a/Editor/Tests/test_runtime_bundle_contents.py
+++ b/Editor/Tests/test_runtime_bundle_contents.py
@@ -1,0 +1,54 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+"""Proves the M2 runtime-bundle mechanism: publishing the probe self-contained
+for the host RID yields a private CoreCLR + hostfxr (no machine .NET needed).
+
+Marked `slow` + skipped when dotnet is unavailable, so it never blocks the fast
+unit run but does exercise the real mechanism on CI (Windows + Linux agents)."""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+PROBE = REPO / "Code" / "Tools" / "RuntimeBundle" / "probe" / "probe.csproj"
+
+# hostfxr + coreclr filenames per host OS (RID inferred from the runner).
+_EXPECTED = {
+    "win32": ("hostfxr.dll", "coreclr.dll"),
+    "linux": ("libhostfxr.so", "libcoreclr.so"),
+    "darwin": ("libhostfxr.dylib", "libcoreclr.dylib"),
+}
+
+
+def _host_key():
+    if sys.platform.startswith("linux"):
+        return "linux"
+    return sys.platform
+
+
+@pytest.mark.slow
+def test_probe_publish_yields_private_runtime(tmp_path):
+    if shutil.which("dotnet") is None:
+        pytest.skip("dotnet not available")
+    if not PROBE.exists():
+        pytest.skip("probe project not present")
+
+    out = tmp_path / "out"
+    result = subprocess.run(
+        ["dotnet", "publish", str(PROBE), "-c", "Release",
+         "--self-contained", "true", "-o", str(out)],
+        capture_output=True, text=True, timeout=600,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    hostfxr, coreclr = _EXPECTED[_host_key()]
+    files = {p.name for p in out.iterdir()}
+    assert hostfxr in files, f"{hostfxr} missing from bundle: {sorted(files)[:20]}"
+    assert coreclr in files, f"{coreclr} missing from bundle"
+    assert "System.Private.CoreLib.dll" in files

--- a/README.md
+++ b/README.md
@@ -839,6 +839,56 @@ The exported launcher package includes all C# runtime files in the correct locat
         └── MyGame.deps.json
 ```
 
+### Shipping without requiring .NET (experimental)
+
+By default, O3DESharp is **framework-dependent**: Coral resolves a machine-wide
+.NET 9 runtime install on the player's machine at startup (`hostfxr` →
+`hostpolicy`, `rollForward: LatestMinor`). That's the supported path today and
+is unchanged by everything below.
+
+M2 adds an **opt-in, experimental** alternative: bundling a private,
+self-contained CoreCLR next to the launcher so a shipped game can run C#
+scripts on a machine with **no .NET installed at all**.
+
+```bash
+cmake -S . -B build -DO3DESHARP_BUNDLE_DOTNET_RUNTIME=ON
+cmake --build build --target O3DESharp.StageRuntimeBundle
+# Re-run configure once more so the produced bundle gets queued for deploy
+# (its file list isn't known until the publish above has actually run):
+cmake -S . -B build
+```
+
+What this does:
+- Publishes `Code/Tools/RuntimeBundle/probe/probe.csproj` with `dotnet publish
+  -c Release -r <rid> --self-contained true` for the desktop RID matching the
+  host platform (`win-x64`, `linux-x64`, `osx-x64`, or `osx-arm64`), which
+  harvests the private CoreCLR + hostfxr runtime pack for that RID.
+- Stages the harvested runtime into the build tree and deploys it to
+  `Bin/Scripts/dotnet/` alongside the existing `Bin/Scripts/Coral/` and
+  `Bin/Scripts/O3DE.Core.dll` deployment.
+
+Known limitations:
+- **Per-RID.** Only desktop RIDs are in scope (no console/mobile).
+- **Untrimmed.** The bundle is a full, untrimmed runtime (~70-200 MB); the
+  reflection/JSON-based dispatch Coral uses fights the .NET trimmer, so
+  trimming is out of scope for now.
+- **Needs the Coral fork's `DotnetRootOverride` support.** Pointing Coral's
+  hostfxr resolution at the bundled runtime instead of the machine-wide one
+  requires a small change in the `WatchDogStudios/Coral` fork
+  (`HostInstance::Initialize` honoring a `dotnet_root` override). That change
+  is tracked separately and is **not yet landed**, so as of this writing the
+  bundle is produced and deployed, but Coral does not yet consume it - the
+  default framework-dependent resolution still runs even with the option on.
+- **Experimental / not configure-verified in every environment.** The CMake
+  step was verified by actually running the `dotnet publish` command it
+  wraps (confirms `hostfxr`/`coreclr`/`System.Private.CoreLib.dll` are
+  produced), but has not been exercised through a full `cmake --configure`
+  against the O3DE engine SDK in every environment. Treat it as
+  experimental until you've verified it in your own build.
+
+The default (`O3DESHARP_BUNDLE_DOTNET_RUNTIME=OFF`) keeps today's
+framework-dependent behavior: players still need .NET 9 installed.
+
 ### Development Workflow vs Export
 
 **During Development:**

--- a/docs/superpowers/plans/2026-07-15-m2-self-contained-deploy.md
+++ b/docs/superpowers/plans/2026-07-15-m2-self-contained-deploy.md
@@ -275,6 +275,31 @@ git commit -m "M2: opt-in CMake step to build+stage+deploy a private .NET runtim
 
 ### Task 4: Coral host wiring (this repo) + fork override (CROSS-REPO)
 
+> ### ⚠️ THIS TASK AS WRITTEN BELOW IS INACCURATE — see the corrections before implementing.
+>
+> It was authored before the Coral side was read. Three things are wrong:
+>
+> 1. **The cross-repo half is already merged** — `WatchDogStudios/Coral` `a98550d` (PR #1) added
+>    `HostSettings::DotnetRootOverride`. Do not redo Step 4, and drop the
+>    `#if CORAL_HAS_DOTNET_ROOT_OVERRIDE` guard in Step 5; the API exists unconditionally.
+> 2. **Coral does not use nethost.** `GetHostFXRPath` hand-rolls a scan of known install
+>    directories rather than calling `get_hostfxr_path`, so there is no
+>    `get_hostfxr_parameters.dotnet_root` to point anywhere. The merged change searches
+>    `<override>/host/fxr` *before* the machine-wide locations.
+> 3. **Step 2's placement does not work.** `Coral::HostSettings` is constructed in
+>    `CoralHostManager::Initialize` at ~line 163, but `coreApiAssemblyPath` is not populated until
+>    `LoadCoreAssembly` at ~line 509 — so no base path is available there to derive the bundle
+>    directory from.
+>
+> **What was actually implemented** (commit on this branch):
+> - `CoralHostConfig::dotnetRootOverride` added in `CoralHostManager.h`.
+> - Forwarded to `settings.DotnetRootOverride` in `CoralHostManager::Initialize`, guarded on
+>   non-empty.
+> - Derived in `O3DESharpSystemComponent.cpp` alongside the sibling `coralDirectory` /
+>   `coreApiAssemblyPath` derivations where `projectPath` is already in scope, honouring a
+>   `/O3DE/O3DESharp/DotnetRootOverride` settings-registry key for consistency, and set **only when
+>   the directory exists** so an absent bundle falls back to the machine install unchanged.
+
 **Files:**
 - Modify: `Code/Source/Scripting/CoralHostManager.h` (add `m_dotnetRootOverride` to `CoralHostConfig`)
 - Modify: `Code/Source/Scripting/CoralHostManager.cpp` (resolve deployed bundle dir; pass override into Coral settings)


### PR DESCRIPTION
Implements Tasks 1–3 and 5 of [the M2 plan](docs/superpowers/plans/2026-07-15-m2-self-contained-deploy.md). **Task 4 is not here** — it needs a cross-repo Coral fork change and is blocked.

## Why

Coral boots a **framework-dependent** runtime: `nethost → hostfxr → hostpolicy` resolves a machine-wide .NET 9 install. So every player of a shipped game must install .NET 9. M2 bundles a private CoreCLR next to the launcher instead.

Everything here is behind `O3DESHARP_BUNDLE_DOTNET_RUNTIME` (**default OFF**), so the current framework-dependent path is byte-for-byte unchanged.

## What's here

- **Runtime-harvest probe** (`Code/Tools/RuntimeBundle/probe`) — a trivial app that is *never shipped*. It exists only so `dotnet publish --self-contained -r <rid>` lays down the private runtime pack, which the CMake step harvests.
- **`o3desharp_runtime_bundle.cmake`** — maps CMake platform → .NET RID and defines `StageRuntimeBundle`, publishing the probe into a per-RID staging dir.
- **Opt-in deploy** into `Bin/Scripts/dotnet/` for the Clients/Servers/Unified launcher targets.
- **A repeatable test** proving the bundle actually ships a private CoreCLR + hostfxr, marked `slow` so it stays out of the fast loop.
- **README**: "Shipping without requiring .NET (experimental)".

## Three plan bugs found and fixed while implementing

Worth calling out, because each would have bitten someone:

1. **The probe csproj wouldn't build.** Its XML comment contained `--self-contained`; `--` is illegal inside an XML comment, so MSBuild failed with `MSB4025`.
2. **`@pytest.mark.slow` does not deselect anything.** Marker registration only suppresses "unknown marker" warnings. Because `dotnet` is present on dev machines, the bundle test would have *actually executed* on every fast run, adding a full publish. Fixed with `-m "not slow"` in `pytest.ini`.
3. **`ly_add_target_files` cannot take a directory.** Traced to its implementation (`LYWrappers.cmake:724` → `runtime_dependencies_common.cmake.in`), which runs `file(SIZE ...)` per entry — that errors on a directory. Every other call site in the engine passes individual named files. The bundle is ~189 files whose names aren't knowable until the publish runs, so the staged dir is `file(GLOB ...)`'d and the discovered files passed instead. Also dropped an `add_dependencies` on the launcher targets — they're `IMPORTED INTERFACE` aliases, where that's illegal.

## Known caveat (documented in-code and in the README)

On the **first configure** after enabling the option, the bundle directory doesn't exist yet — `StageRuntimeBundle` only produces it at *build* time — so the glob is empty and nothing is queued that configure. Build `StageRuntimeBundle` once, then re-run configure. Not elegant; called out rather than hidden.

## Verification

- **The mechanism is proven, not assumed.** A real `dotnet publish --self-contained` for `win-x64` produced **189 files** including `hostfxr.dll`, `coreclr.dll`, `clrjit.dll`, `System.Private.CoreLib.dll` — all flat, which is what makes the non-recursive glob safe. A `linux-x64` cross-publish from Windows was verified earlier and yields the `.so` equivalents.
- Python: **102 passed, 1 deselected**. C#: **45 passed**.
- **The CMake is NOT configure-verified** — no O3DE engine SDK in the authoring environment. Both CMake commits say so. Balance-checked and the wrapped `dotnet publish` command was exercised for real, but a genuine configure + build is required before trusting it.

## Not in this PR

Task 4 — passing the bundle directory to Coral as a `dotnet_root` override, plus the matching `DotnetRootOverride` support in `WatchDogStudios/Coral`. **Until that lands, the bundle is staged and deployed but not yet used**: Coral still resolves the machine-wide runtime. This PR is the delivery half; Task 4 is the consumption half.