### PR TITLE
SP-1b-1: native binding manifest — offline half

### DIFF
--- a/Code/Tools/BindingGenerator.Tests/NativeBindingCliTests.cs
+++ b/Code/Tools/BindingGenerator.Tests/NativeBindingCliTests.cs
@@ -1,0 +1,64 @@
+//
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// For complete copyright and license terms please see the LICENSE at the root of this distribution.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+using System.IO;
+using System.Text.Json;
+using O3DESharp.BindingGenerator.Configuration;
+using O3DESharp.BindingGenerator.Generation;
+
+namespace O3DESharp.BindingGenerator.Tests;
+
+/// <summary>
+/// End-to-end over the offline half: a manifest emitted by the C++ pass plus a
+/// set of recovered call sites produces a joined manifest whose bound entries
+/// carry real symbols. The runtime half (registry, load-time validation,
+/// dispatch) is SP-1b-2 and not exercised here.
+/// </summary>
+public class NativeBindingCliTests
+{
+    [Fact]
+    public void JoinedManifest_IsWrittenWithSymbolsFilledIn()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var manifestPath = Path.Combine(dir, "native_bindings.json");
+            File.WriteAllText(manifestPath, """
+            {"methods":[{
+              "reflected_name":"GetLength","owning_class_name":"Vector3",
+              "owning_class_type_id":"{0}","owning_class_size_bytes":16,"owning_class_align_bytes":16,
+              "is_static":false,"is_const":true,"native_qualified_symbol":"",
+              "return":{"name":"","cpp_type_name":"float","type_id":"{1}","storage_class":"Value","size_bytes":4,"align_bytes":4},
+              "arguments":[],"bindable":false,"non_bindable_reason":"NoNativeSideCounterpart",
+              "binding_id":"Vector3::GetLength"}]}
+            """);
+
+            var doc = JsonSerializer.Deserialize<NativeBindingManifestDocument>(
+                File.ReadAllText(manifestPath))!;
+
+            var report = NativeBindingJoin.Apply(
+                doc,
+                new[] { new CallSiteSymbol("Vector3", "GetLength", "AZ::Vector3::GetLength", false) });
+
+            var outPath = Path.Combine(dir, "native_bindings.joined.json");
+            File.WriteAllText(outPath, JsonSerializer.Serialize(doc));
+
+            var reloaded = JsonSerializer.Deserialize<NativeBindingManifestDocument>(
+                File.ReadAllText(outPath))!;
+
+            report.Bound.Should().Be(1);
+            reloaded.Methods[0].Bindable.Should().BeTrue();
+            reloaded.Methods[0].NativeQualifiedSymbol.Should().Be("AZ::Vector3::GetLength");
+            reloaded.Methods[0].BindingId.Should().Be("Vector3::GetLength");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/Code/Tools/BindingGenerator.Tests/NativeBindingJoinTests.cs
+++ b/Code/Tools/BindingGenerator.Tests/NativeBindingJoinTests.cs
@@ -1,0 +1,177 @@
+//
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// For complete copyright and license terms please see the LICENSE at the root of this distribution.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+using System.Collections.Generic;
+using System.Linq;
+using O3DESharp.BindingGenerator.Configuration;
+using O3DESharp.BindingGenerator.Generation;
+
+namespace O3DESharp.BindingGenerator.Tests;
+
+/// <summary>
+/// The join is the one place a mistake produces a WRONG binding rather than a
+/// missing one. A missing binding falls back to BehaviorMethod::Call and costs
+/// speed; a wrong one calls a function pointer with a mismatched signature.
+/// Every ambiguous case must therefore resolve to "not bindable".
+/// </summary>
+public class NativeBindingJoinTests
+{
+    private static NativeBindingManifestMethod Method(
+        string cls, string name, bool isStatic = false, params string[] argStorageClasses)
+    {
+        return new NativeBindingManifestMethod
+        {
+            ReflectedName = name,
+            OwningClassName = cls,
+            OwningClassTypeId = "{00000000-0000-0000-0000-000000000001}",
+            IsStatic = isStatic,
+            BindingId = $"{cls}::{name}",
+            Return = new NativeBindingManifestArgument { CppTypeName = "void", StorageClass = "Value" },
+            Arguments = argStorageClasses
+                .Select(sc => new NativeBindingManifestArgument { StorageClass = sc, CppTypeName = "int" })
+                .ToList(),
+        };
+    }
+
+    private static NativeBindingManifestDocument Doc(params NativeBindingManifestMethod[] methods)
+        => new() { Methods = methods.ToList() };
+
+    [Fact]
+    public void MatchingCallSite_PopulatesSymbolAndBinds()
+    {
+        var doc = Doc(Method("Vector3", "GetLength"));
+        var sites = new[] { new CallSiteSymbol("Vector3", "GetLength", "AZ::Vector3::GetLength", false) };
+
+        var report = NativeBindingJoin.Apply(doc, sites);
+
+        doc.Methods[0].NativeQualifiedSymbol.Should().Be("AZ::Vector3::GetLength");
+        doc.Methods[0].Bindable.Should().BeTrue();
+        doc.Methods[0].NonBindableReason.Should().Be("None");
+        report.Bound.Should().Be(1);
+    }
+
+    [Fact]
+    public void NoMatchingCallSite_IsUnresolvedNotBound()
+    {
+        var doc = Doc(Method("Vector3", "GetLength"));
+
+        var report = NativeBindingJoin.Apply(doc, System.Array.Empty<CallSiteSymbol>());
+
+        doc.Methods[0].Bindable.Should().BeFalse();
+        doc.Methods[0].NonBindableReason.Should().Be("UnresolvedNativeSymbol");
+        doc.Methods[0].NativeQualifiedSymbol.Should().BeEmpty();
+        report.Bound.Should().Be(0);
+    }
+
+    [Fact]
+    public void SameReflectedNameOnDifferentClasses_DoesNotCrossJoin()
+    {
+        // The join key is (className, reflectedName). If it ever degrades to
+        // reflectedName alone, Transform::GetLength would bind to
+        // AZ::Vector3::GetLength - a wrong pointer with a plausible name.
+        var doc = Doc(Method("Vector3", "GetLength"), Method("Transform", "GetLength"));
+        var sites = new[] { new CallSiteSymbol("Vector3", "GetLength", "AZ::Vector3::GetLength", false) };
+
+        NativeBindingJoin.Apply(doc, sites);
+
+        doc.Methods.Single(m => m.OwningClassName == "Vector3").NativeQualifiedSymbol
+            .Should().Be("AZ::Vector3::GetLength");
+        doc.Methods.Single(m => m.OwningClassName == "Transform").NativeQualifiedSymbol
+            .Should().BeEmpty("Transform::GetLength has no call site and must not inherit Vector3's symbol");
+    }
+
+    [Fact]
+    public void DuplicateCallSitesForSameKey_RefusesToBind()
+    {
+        // Two different &C::Method expressions reflected under one script name
+        // means an overload set. Picking either is a coin flip, so bind neither.
+        var doc = Doc(Method("Vector3", "Set"));
+        var sites = new[]
+        {
+            new CallSiteSymbol("Vector3", "Set", "AZ::Vector3::Set", false),
+            new CallSiteSymbol("Vector3", "Set", "AZ::Vector3::SetFloat3", false),
+        };
+
+        NativeBindingJoin.Apply(doc, sites);
+
+        doc.Methods[0].Bindable.Should().BeFalse();
+        doc.Methods[0].NonBindableReason.Should().Be("Overloaded");
+    }
+
+    [Fact]
+    public void LambdaReflectedCallSite_IsNotBound()
+    {
+        var doc = Doc(Method("Vector3", "Weird"));
+        var sites = new[] { new CallSiteSymbol("Vector3", "Weird", "", true) };
+
+        NativeBindingJoin.Apply(doc, sites);
+
+        doc.Methods[0].Bindable.Should().BeFalse();
+        doc.Methods[0].NonBindableReason.Should().Be("ReflectedViaLambda");
+    }
+
+    [Fact]
+    public void UnknownArgStorageClass_IsNotBound()
+    {
+        var doc = Doc(Method("Vector3", "Odd", false, "Value", "Unknown"));
+        var sites = new[] { new CallSiteSymbol("Vector3", "Odd", "AZ::Vector3::Odd", false) };
+
+        NativeBindingJoin.Apply(doc, sites);
+
+        doc.Methods[0].Bindable.Should().BeFalse();
+        doc.Methods[0].NonBindableReason.Should().Be("UnsupportedArgStorage");
+    }
+
+    [Fact]
+    public void UnknownReturnStorageClass_IsNotBound()
+    {
+        var doc = Doc(Method("Vector3", "OddRet"));
+        doc.Methods[0].Return.StorageClass = "Unknown";
+        doc.Methods[0].Return.CppTypeName = "SomethingExotic";
+        var sites = new[] { new CallSiteSymbol("Vector3", "OddRet", "AZ::Vector3::OddRet", false) };
+
+        NativeBindingJoin.Apply(doc, sites);
+
+        doc.Methods[0].Bindable.Should().BeFalse();
+        doc.Methods[0].NonBindableReason.Should().Be("UnsupportedArgStorage");
+    }
+
+    [Fact]
+    public void VoidReturn_IsBindable()
+    {
+        // "void" carries StorageClass Value but is not a real value - it must
+        // not be mistaken for an unsupported storage class.
+        var doc = Doc(Method("Vector3", "Reset"));
+        var sites = new[] { new CallSiteSymbol("Vector3", "Reset", "AZ::Vector3::Reset", false) };
+
+        NativeBindingJoin.Apply(doc, sites);
+
+        doc.Methods[0].Bindable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Report_CountsReasons()
+    {
+        var doc = Doc(
+            Method("A", "Ok"),
+            Method("B", "Missing"),
+            Method("C", "Lambda"));
+        var sites = new[]
+        {
+            new CallSiteSymbol("A", "Ok", "AZ::A::Ok", false),
+            new CallSiteSymbol("C", "Lambda", "", true),
+        };
+
+        var report = NativeBindingJoin.Apply(doc, sites);
+
+        report.Total.Should().Be(3);
+        report.Bound.Should().Be(1);
+        report.Unbound.Should().Be(2);
+        report.ReasonCounts["UnresolvedNativeSymbol"].Should().Be(1);
+        report.ReasonCounts["ReflectedViaLambda"].Should().Be(1);
+    }
+}

--- a/Code/Tools/BindingGenerator.Tests/NativeBindingManifestSchemaTests.cs
+++ b/Code/Tools/BindingGenerator.Tests/NativeBindingManifestSchemaTests.cs
@@ -1,0 +1,102 @@
+//
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// For complete copyright and license terms please see the LICENSE at the root of this distribution.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+using System.Text.Json;
+using O3DESharp.BindingGenerator.Configuration;
+
+namespace O3DESharp.BindingGenerator.Tests;
+
+/// <summary>
+/// The manifest JSON is the contract between the C++ exporter
+/// (NativeBindingManifestExporter) and this generator. The property names are
+/// the wire format: renaming one silently produces a manifest where every
+/// method looks unbindable, which degrades to the slow path rather than
+/// failing loudly. These pin the names.
+/// </summary>
+public class NativeBindingManifestSchemaTests
+{
+    private const string SampleJson = """
+    {
+      "methods": [
+        {
+          "reflected_name": "GetLength",
+          "owning_class_name": "Vector3",
+          "owning_class_type_id": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+          "owning_class_size_bytes": 16,
+          "owning_class_align_bytes": 16,
+          "is_static": false,
+          "is_const": true,
+          "native_qualified_symbol": "",
+          "return": {
+            "name": "", "cpp_type_name": "float", "type_id": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+            "storage_class": "Value", "size_bytes": 4, "align_bytes": 4
+          },
+          "arguments": [],
+          "bindable": false,
+          "non_bindable_reason": "NoNativeSideCounterpart",
+          "binding_id": "Vector3::GetLength"
+        }
+      ]
+    }
+    """;
+
+    [Fact]
+    public void Deserializes_TheCppExporterWireFormat()
+    {
+        var doc = JsonSerializer.Deserialize<NativeBindingManifestDocument>(SampleJson);
+
+        doc.Should().NotBeNull();
+        doc!.Methods.Should().ContainSingle();
+
+        var m = doc.Methods[0];
+        m.ReflectedName.Should().Be("GetLength");
+        m.OwningClassName.Should().Be("Vector3");
+        m.OwningClassSizeBytes.Should().Be(16);
+        m.IsConst.Should().BeTrue();
+        m.IsStatic.Should().BeFalse();
+        m.BindingId.Should().Be("Vector3::GetLength");
+        m.Return.CppTypeName.Should().Be("float");
+        m.Return.StorageClass.Should().Be("Value");
+    }
+
+    [Fact]
+    public void CppExporterLeavesTheJoinedFieldsUnset()
+    {
+        // The runtime BehaviorContext pass cannot recover a native symbol and
+        // does not classify. Both are this generator's job; if the exporter
+        // ever starts filling them, the join must be revisited.
+        var doc = JsonSerializer.Deserialize<NativeBindingManifestDocument>(SampleJson)!;
+        var m = doc.Methods[0];
+
+        m.NativeQualifiedSymbol.Should().BeEmpty();
+        m.Bindable.Should().BeFalse();
+        m.NonBindableReason.Should().Be("NoNativeSideCounterpart");
+    }
+
+    [Fact]
+    public void RoundTripsWithoutLosingFields()
+    {
+        var doc = JsonSerializer.Deserialize<NativeBindingManifestDocument>(SampleJson)!;
+        doc.Methods[0].NativeQualifiedSymbol = "AZ::Vector3::GetLength";
+        doc.Methods[0].Bindable = true;
+        doc.Methods[0].NonBindableReason = "None";
+
+        var json = JsonSerializer.Serialize(doc);
+        var again = JsonSerializer.Deserialize<NativeBindingManifestDocument>(json)!;
+
+        again.Methods[0].NativeQualifiedSymbol.Should().Be("AZ::Vector3::GetLength");
+        again.Methods[0].Bindable.Should().BeTrue();
+        again.Methods[0].BindingId.Should().Be("Vector3::GetLength");
+    }
+
+    [Fact]
+    public void EmptyManifestIsValid()
+    {
+        var doc = JsonSerializer.Deserialize<NativeBindingManifestDocument>("""{"methods":[]}""");
+        doc!.Methods.Should().BeEmpty();
+    }
+}

--- a/Code/Tools/BindingGenerator.Tests/ReflectionCallSiteParserTests.cs
+++ b/Code/Tools/BindingGenerator.Tests/ReflectionCallSiteParserTests.cs
@@ -1,0 +1,111 @@
+//
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// For complete copyright and license terms please see the LICENSE at the root of this distribution.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+using System.IO;
+using System.Linq;
+using O3DESharp.BindingGenerator.Parsing;
+
+namespace O3DESharp.BindingGenerator.Tests;
+
+/// <summary>
+/// Recovering `&amp;C::Method` from a reflection .cpp is the only way to learn a
+/// native symbol - BehaviorContext type-erases it behind an AZStd::function, so
+/// no runtime pass can supply it. These use small real C++ fixtures rather than
+/// mocks, because what is being tested is precisely whether libclang sees what
+/// we think it sees.
+/// </summary>
+public class ReflectionCallSiteParserTests
+{
+    private static string WriteFixture(string dir, string name, string source)
+    {
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, name);
+        File.WriteAllText(path, source, System.Text.Encoding.UTF8);
+        return path;
+    }
+
+    [Fact]
+    public void RecoversPlainMemberFunctionPointer()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
+        {
+            var path = WriteFixture(dir, "Reflect.cpp", """
+            struct BehaviorContext {
+                template<class T> BehaviorContext* Class(const char*) { return this; }
+                template<class F> BehaviorContext* Method(const char*, F) { return this; }
+            };
+            struct Vector3 { float GetLength() const { return 0.0f; } };
+            void Reflect(BehaviorContext* c) {
+                c->Class<Vector3>("Vector3")->Method("GetLength", &Vector3::GetLength);
+            }
+            """);
+
+            var parser = new ReflectionCallSiteParser(verbose: false);
+            var result = parser.ParseFile(path, new[] { dir }, System.Array.Empty<string>());
+
+            var site = result.CallSites.Should().ContainSingle().Subject;
+            site.ReflectedName.Should().Be("GetLength");
+            site.NativeQualifiedSymbol.Should().Contain("Vector3::GetLength");
+            site.ViaLambda.Should().BeFalse();
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void FlagsLambdaReflectedMethodRatherThanGuessing()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
+        {
+            var path = WriteFixture(dir, "Reflect.cpp", """
+            struct BehaviorContext {
+                template<class T> BehaviorContext* Class(const char*) { return this; }
+                template<class F> BehaviorContext* Method(const char*, F) { return this; }
+            };
+            struct Vector3 { float GetLength() const { return 0.0f; } };
+            void Reflect(BehaviorContext* c) {
+                c->Class<Vector3>("Vector3")->Method("Weird", [](Vector3* v) { return 1.0f; });
+            }
+            """);
+
+            var parser = new ReflectionCallSiteParser(verbose: false);
+            var result = parser.ParseFile(path, new[] { dir }, System.Array.Empty<string>());
+
+            var site = result.CallSites.Should().ContainSingle().Subject;
+            site.ReflectedName.Should().Be("Weird");
+            site.ViaLambda.Should().BeTrue("a lambda has no &C::Method symbol to bind");
+            site.NativeQualifiedSymbol.Should().BeEmpty();
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void FileWithNoReflection_YieldsNoCallSites()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
+        {
+            var path = WriteFixture(dir, "Plain.cpp", "int main() { return 0; }\n");
+
+            var parser = new ReflectionCallSiteParser(verbose: false);
+            var result = parser.ParseFile(path, new[] { dir }, System.Array.Empty<string>());
+
+            result.CallSites.Should().BeEmpty();
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Configuration/NativeBindingManifestSchema.cs
+++ b/Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Configuration/NativeBindingManifestSchema.cs
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace O3DESharp.BindingGenerator.Configuration
+{
+    // POCO mirror of the JSON schema emitted by O3DESharp's C++
+    // NativeBindingManifestExporter (Code/Source/Scripting/Reflection/
+    // NativeBindingManifest.cpp). This is a DIFFERENT schema from
+    // ReflectionDataSchema.cs's ReflectionDocument - that one mirrors
+    // ReflectionDataExporter's reflection_data.json (the general "what
+    // got reflected" dump used by the C#-wrapper generator);  this one
+    // mirrors the native-binding manifest (the 1B-specific "what can be
+    // called as a direct native trampoline" dump). Any change to the C++
+    // NativeBindingManifestExporter needs a matching change here.
+
+    public sealed class NativeBindingManifestArgument
+    {
+        [JsonPropertyName("name")]          public string Name { get; set; } = string.Empty;
+        [JsonPropertyName("cpp_type_name")] public string CppTypeName { get; set; } = string.Empty;
+        [JsonPropertyName("type_id")]       public string TypeId { get; set; } = string.Empty;
+
+        /// <summary>One of: Value, Pointer, Reference, ConstReference, Unknown.</summary>
+        [JsonPropertyName("storage_class")] public string StorageClass { get; set; } = "Unknown";
+        [JsonPropertyName("size_bytes")]    public long SizeBytes { get; set; }
+        [JsonPropertyName("align_bytes")]   public long AlignBytes { get; set; }
+    }
+
+    public sealed class NativeBindingManifestMethod
+    {
+        [JsonPropertyName("reflected_name")]           public string ReflectedName { get; set; } = string.Empty;
+        [JsonPropertyName("owning_class_name")]         public string OwningClassName { get; set; } = string.Empty;
+        [JsonPropertyName("owning_class_type_id")]      public string OwningClassTypeId { get; set; } = string.Empty;
+        [JsonPropertyName("owning_class_size_bytes")]   public long OwningClassSizeBytes { get; set; }
+        [JsonPropertyName("owning_class_align_bytes")]  public long OwningClassAlignBytes { get; set; }
+        [JsonPropertyName("is_static")]                 public bool IsStatic { get; set; }
+        [JsonPropertyName("is_const")]                   public bool IsConst { get; set; }
+
+        /// <summary>
+        /// Always empty as emitted by the C++ exporter (see
+        /// NativeBindingManifest.h's class doc - the runtime
+        /// BehaviorContext pass cannot recover this). Populated by
+        /// NativeBindingGenerator's join against ReflectionCallSiteParser
+        /// output before this record is re-serialized / used to emit a
+        /// trampoline.
+        /// </summary>
+        [JsonPropertyName("native_qualified_symbol")]   public string NativeQualifiedSymbol { get; set; } = string.Empty;
+
+        [JsonPropertyName("return")]     public NativeBindingManifestArgument Return { get; set; } = new();
+        [JsonPropertyName("arguments")]  public List<NativeBindingManifestArgument> Arguments { get; set; } = new();
+
+        /// <summary>
+        /// Always false as emitted by the C++ exporter. Set by
+        /// NativeBindingGenerator's BindingClassifier after the join.
+        /// </summary>
+        [JsonPropertyName("bindable")]            public bool Bindable { get; set; }
+
+        /// <summary>
+        /// One of the NonBindableReason enumerators (see
+        /// NativeBindingManifest.h): None, Overloaded, ReflectedViaLambda,
+        /// OnDemandTemplateType, EBusAddressedById, UnresolvedNativeSymbol,
+        /// UnsupportedArgStorage, NoNativeSideCounterpart.
+        /// </summary>
+        [JsonPropertyName("non_bindable_reason")]  public string NonBindableReason { get; set; } = "NoNativeSideCounterpart";
+
+        [JsonPropertyName("binding_id")]           public string BindingId { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Top-level shape of the native-binding manifest JSON dumped by
+    /// NativeBindingManifestExporter::ExportToString. Loaded once by
+    /// NativeBindingGenerator, joined against ReflectionCallSiteParser
+    /// output, classified, and used to drive trampoline emission.
+    /// </summary>
+    public sealed class NativeBindingManifestDocument
+    {
+        [JsonPropertyName("methods")] public List<NativeBindingManifestMethod> Methods { get; set; } = new();
+    }
+}

--- a/Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Generation/NativeBindingJoin.cs
+++ b/Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Generation/NativeBindingJoin.cs
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using O3DESharp.BindingGenerator.Configuration;
+
+namespace O3DESharp.BindingGenerator.Generation
+{
+    /// <summary>One recovered `->Method("name", &amp;C::Method)` reflection call site.</summary>
+    /// <param name="ClassName">Reflected class name, matching the manifest's owning_class_name.</param>
+    /// <param name="ReflectedName">The script-visible name passed to ->Method(...).</param>
+    /// <param name="NativeQualifiedSymbol">e.g. "AZ::Vector3::GetLength". Empty when ViaLambda.</param>
+    /// <param name="ViaLambda">True when the call site passed a lambda/wrapper rather than &amp;C::Method.</param>
+    public sealed record CallSiteSymbol(
+        string ClassName,
+        string ReflectedName,
+        string NativeQualifiedSymbol,
+        bool ViaLambda);
+
+    /// <summary>Aggregate outcome of a join, for logging and coverage assertions.</summary>
+    public sealed record JoinReport(
+        int Total,
+        int Bound,
+        int Unbound,
+        IReadOnlyDictionary<string, int> ReasonCounts);
+
+    /// <summary>
+    /// Joins the C++ runtime manifest against libclang-recovered call sites and
+    /// classifies what may be bound as a native trampoline.
+    ///
+    /// Deliberately pure: no file, no libclang, no engine. The join is the one
+    /// place an error yields a WRONG binding rather than a missing one - calling
+    /// a function pointer with a mismatched signature - so it has to be provable
+    /// with plain in-memory data.
+    ///
+    /// Every ambiguity resolves toward NOT binding. An unbound method falls back
+    /// to BehaviorMethod::Call and merely costs speed.
+    /// </summary>
+    public static class NativeBindingJoin
+    {
+        private const string StorageUnknown = "Unknown";
+
+        public static JoinReport Apply(
+            NativeBindingManifestDocument manifest,
+            IReadOnlyCollection<CallSiteSymbol> callSites)
+        {
+            ArgumentNullException.ThrowIfNull(manifest);
+            ArgumentNullException.ThrowIfNull(callSites);
+
+            // Key on (className, reflectedName). Never on reflectedName alone:
+            // Transform::GetLength and Vector3::GetLength are different methods
+            // that share a script name, and cross-joining them would bind a
+            // plausible-looking but wrong pointer.
+            var byKey = new Dictionary<(string, string), List<CallSiteSymbol>>();
+            foreach (var site in callSites)
+            {
+                var key = (site.ClassName, site.ReflectedName);
+                if (!byKey.TryGetValue(key, out var list))
+                {
+                    list = new List<CallSiteSymbol>();
+                    byKey[key] = list;
+                }
+                list.Add(site);
+            }
+
+            var reasons = new Dictionary<string, int>();
+            int bound = 0;
+
+            foreach (var method in manifest.Methods)
+            {
+                var reason = Classify(method, byKey, out string symbol);
+
+                if (reason == "None")
+                {
+                    method.NativeQualifiedSymbol = symbol;
+                    method.Bindable = true;
+                    method.NonBindableReason = "None";
+                    bound++;
+                }
+                else
+                {
+                    method.NativeQualifiedSymbol = string.Empty;
+                    method.Bindable = false;
+                    method.NonBindableReason = reason;
+                    reasons[reason] = reasons.GetValueOrDefault(reason) + 1;
+                }
+            }
+
+            return new JoinReport(
+                manifest.Methods.Count, bound, manifest.Methods.Count - bound, reasons);
+        }
+
+        private static string Classify(
+            NativeBindingManifestMethod method,
+            Dictionary<(string, string), List<CallSiteSymbol>> byKey,
+            out string symbol)
+        {
+            symbol = string.Empty;
+
+            if (!byKey.TryGetValue((method.OwningClassName, method.ReflectedName), out var sites)
+                || sites.Count == 0)
+            {
+                return "UnresolvedNativeSymbol";
+            }
+
+            // More than one distinct &C::Method under a single script name is an
+            // overload set. Choosing either is a coin flip; bind neither.
+            var distinct = sites
+                .Select(s => s.NativeQualifiedSymbol)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+            if (sites.Count > 1 && distinct.Count > 1)
+            {
+                return "Overloaded";
+            }
+
+            if (sites.Any(s => s.ViaLambda))
+            {
+                return "ReflectedViaLambda";
+            }
+
+            if (string.IsNullOrEmpty(distinct[0]))
+            {
+                return "UnresolvedNativeSymbol";
+            }
+
+            // "void" is spelled with StorageClass Value but is not a value the
+            // emitter has to unpack, so it must not trip the Unknown check.
+            bool returnIsVoid = string.Equals(method.Return?.CppTypeName, "void", StringComparison.Ordinal);
+            if (!returnIsVoid && method.Return?.StorageClass == StorageUnknown)
+            {
+                return "UnsupportedArgStorage";
+            }
+
+            if (method.Arguments.Any(a => a.StorageClass == StorageUnknown))
+            {
+                return "UnsupportedArgStorage";
+            }
+
+            symbol = distinct[0];
+            return "None";
+        }
+    }
+}

--- a/Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Parsing/ReflectionCallSiteParser.cs
+++ b/Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Parsing/ReflectionCallSiteParser.cs
@@ -1,0 +1,829 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using ClangSharp;
+using ClangSharp.Interop;
+
+namespace O3DESharp.BindingGenerator.Parsing
+{
+    /// <summary>
+    /// One recovered reflection call-site: a single
+    /// <c>-&gt;Method("Name", &amp;C::Symbol, ...)</c> (or Property/Event/
+    /// Constructor) expression found in a gem's Reflect() implementation.
+    /// </summary>
+    public sealed class ReflectionCallSite
+    {
+        /// <summary>
+        /// "Method", "Property", "Event", or "Constructor" - the reflection
+        /// builder method name that was called (AZ::BehaviorContext::
+        /// ClassBuilder::Method / Property / EBusBuilder::Event / etc. all
+        /// share this fluent-chain shape; see BehaviorContext.h /
+        /// BehaviorClassBuilder.inl).
+        /// </summary>
+        public string ReflectionKind { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The reflected (script-visible) name - the first string-literal
+        /// argument to the call, e.g. "GetLength". This is what
+        /// BehaviorContextReflector/ManifestMethodEntry.reflectedName also
+        /// captures at runtime; it is the join key back to the C++-side
+        /// manifest (see ReflectionCallSiteParser class doc for why this,
+        /// not the decl name, has to be the key).
+        /// </summary>
+        public string ReflectedName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The owning class as spelled at the call site's enclosing
+        /// Reflect() scope, e.g. "Vector3". Empty for EBus-global /
+        /// non-class reflection blocks (BehaviorContext::Method(...) at
+        /// namespace scope, or EBus builder chains where the class is the
+        /// bus itself rather than a C++ type - those still populate
+        /// EnclosingBusName instead).
+        /// </summary>
+        public string OwningClassName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Populated instead of/alongside OwningClassName when this call
+        /// site is inside an EBus<...>::Behavior chain (i.e. reflects an
+        /// EBus event, not a class method). The 1B v1 classifier always
+        /// marks these NonBindableReason::EBusAddressedById OR (for
+        /// broadcast events) simply doesn't attempt to bind them - see
+        /// NativeBindingGenerator.cs's classifier - but the parser still
+        /// records them for census/coverage-report purposes (spec §8 R7).
+        /// </summary>
+        public string EnclosingBusName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The recovered qualified C++ symbol from the
+        /// <c>&amp;C::Method</c> argument, e.g. "AZ::Vector3::GetLength".
+        /// Empty if the second argument to Method(...)/Event(...) was NOT
+        /// a plain address-of-member-or-free-function expression (a
+        /// lambda, a bound AZStd::function, a macro-expanded wrapper,
+        /// etc.) - see ClassifyMethodArgument. An empty symbol here is
+        /// the parser-side signal that feeds
+        /// NonBindableReason::ReflectedViaLambda.
+        /// </summary>
+        public string NativeQualifiedSymbol { get; set; } = string.Empty;
+
+        /// <summary>
+        /// True only when the second argument was recognized as exactly
+        /// <c>&amp;Qualified::Name</c> (a UnaryOperator '&amp;' over a
+        /// DeclRefExpr / MemberExpr naming a function or method). False
+        /// for every other shape (lambda, functor object, overload-
+        /// disambiguating cast, nullptr, etc.) - those are exactly the
+        /// "reflected via lambda/wrapper" non-bindable case from the spec.
+        /// </summary>
+        public bool IsPlainMemberPointer { get; set; }
+
+        /// <summary>
+        /// True if the reflection call-site chain this belongs to also
+        /// contains an ->Overload(...)/m_overload marker OR the same
+        /// ReflectedName occurs more than once for the same
+        /// OwningClassName within one gem's parsed call sites (arity/type
+        /// overloading reflected as repeat ->Method() calls with the same
+        /// script name - the common O3DE pattern for exposing C++
+        /// overloads to script under one name). The join step
+        /// (NativeBindingGenerator.BindingClassifier) is what actually
+        /// aggregates duplicates across the whole parse and sets this;
+        /// the parser leaves it false and only records raw call sites.
+        /// </summary>
+        public bool LooksOverloaded { get; set; }
+
+        /// <summary>Source file this call site was found in (for diagnostics).</summary>
+        public string SourceFile { get; set; } = string.Empty;
+
+        /// <summary>1-based source line (for diagnostics / stable sorting).</summary>
+        public uint SourceLine { get; set; }
+    }
+
+    /// <summary>
+    /// Container for every reflection call site recovered from one gem's
+    /// reflection .cpp files.
+    /// </summary>
+    public sealed class ReflectionCallSiteResult
+    {
+        public string GemName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Raw parser-internal call sites, carrying the extra fields
+        /// (ReflectionKind, EnclosingBusName, LooksOverloaded, source
+        /// location) that only this parser needs.
+        /// </summary>
+        public List<ReflectionCallSite> RawCallSites { get; } = new List<ReflectionCallSite>();
+
+        /// <summary>
+        /// Projection onto Task 2's join type (Generation.CallSiteSymbol).
+        /// The join only needs (className, reflectedName, symbol,
+        /// viaLambda) - not this parser's diagnostic-only fields - so this
+        /// is a pure read-through, not a second source of truth.
+        /// ViaLambda is the negation of IsPlainMemberPointer: in v1 scope,
+        /// "not a plain &amp;C::Method reference" and "reflected via a
+        /// lambda/wrapper" are the same case (see ClassifyMethodArgument).
+        /// </summary>
+        public IReadOnlyList<Generation.CallSiteSymbol> CallSites =>
+            RawCallSites
+                .ConvertAll(site => new Generation.CallSiteSymbol(
+                    site.OwningClassName,
+                    site.ReflectedName,
+                    site.NativeQualifiedSymbol,
+                    !site.IsPlainMemberPointer));
+    }
+
+    /// <summary>
+    /// Parses a gem's REFLECTION .cpp FILES (not headers - see
+    /// O3DEHeaderParser, which only ever visits header ClassDecl/
+    /// FunctionDecl and never opens a .cpp or visits a CallExpr) to
+    /// recover the native C++ symbol backing each BehaviorContext
+    /// reflection entry.
+    ///
+    /// THIS IS THE PIECE THE 1B SPEC IDENTIFIES AS MISSING (§3 point 2 /
+    /// §6.1): AZ::BehaviorContext stores no native symbol at runtime -
+    /// BehaviorMethodImpl's functor captures a raw fn-pointer inside a
+    /// type-erased AZStd::function, and only the reflected (script) name
+    /// is queryable from a live BehaviorContext (BehaviorMethod has no
+    /// "give me back the &C::Method you were constructed from" accessor).
+    /// The ONLY place the qualified symbol still exists as readable text
+    /// is the call-site source itself:
+    ///
+    ///     behaviorContext->Class&lt;Vector3&gt;("Vector3")
+    ///         ->Method("GetLength", &amp;Vector3::GetLength, ...)
+    ///
+    /// This parser walks that .cpp with libclang, looking for CallExpr
+    /// nodes whose callee is named Method/Property/Event/Constructor
+    /// (BehaviorContext::ClassBuilder's fluent-chain methods - see
+    /// AzCore/RTTI/BehaviorContext.h / BehaviorClassBuilder.inl), and
+    /// extracts:
+    ///   - the first string-literal argument (the reflected/script name)
+    ///   - the second argument, IF it is a plain `&Qualified::Symbol`
+    ///     UnaryOperator('&') over a DeclRefExpr/MemberExpr - the
+    ///     qualified name of THAT decl is the native symbol.
+    ///
+    /// WHY THE JOIN KEY IS THE REFLECTED NAME, NOT THE C++ DECL NAME:
+    /// the reflected script-name legitimately diverges from the C++
+    /// symbol (`->Method("ScriptFriendlyName", &amp;C::InternalCppName)`
+    /// is a real, supported O3DE pattern - see spec §3 point 2). Since
+    /// BehaviorContextReflector (the runtime C++ side) can only ever see
+    /// the reflected name, and THIS parser is the only place that can see
+    /// both the reflected name AND the C++ symbol simultaneously (they're
+    /// adjacent arguments in the same call expression), the join must
+    /// happen HERE at parse time by keying on (owning class spelling,
+    /// reflected name) exactly as they appear in this one call site - not
+    /// as a later cross-reference between two independently-produced
+    /// lists. NativeBindingGenerator.cs's join against the C++-side
+    /// manifest then only has to match strings, not re-derive anything.
+    ///
+    /// SCOPE / LIMITATIONS (v1, matches the spec's "conservative
+    /// classifier"):
+    ///   - Only recognizes literal `&Class::Method` / `&FreeFunction`
+    ///     as the reflected callable. Lambdas
+    ///     (`->Method("X", []{...})`), `AZStd::function` wrappers, and
+    ///     macro-expanded indirections (AZ_EBUS_BEHAVIOR_BINDER-style
+    ///     thunks) are recorded with IsPlainMemberPointer=false and an
+    ///     empty NativeQualifiedSymbol - the generator's classifier turns
+    ///     that into NonBindableReason::ReflectedViaLambda.
+    ///   - Does not attempt overload resolution/disambiguation casts
+    ///     (`static_cast<Ret(Class::*)(Args)>(&Class::Method)`) in v1;
+    ///     these are detected (the cast wraps a nested UnaryOperator '&')
+    ///     but treated the same as "found a symbol" for the base name -
+    ///     actual overload safety is enforced downstream by
+    ///     LooksOverloaded / the generator's per-class duplicate-name
+    ///     scan, which is a stronger and simpler signal than trying to
+    ///     parse the cast's parameter-type-list text.
+    ///   - Only visits .cpp translation units named on the CALLER'S
+    ///     "reflection sources" list (see ParseReflectionSources) - unlike
+    ///     O3DEHeaderParser this does NOT walk a gem's entire header set,
+    ///     since Reflect() implementations live in .cpp files by O3DE
+    ///     convention and re-parsing every header as a full TU here would
+    ///     duplicate O3DEHeaderParser's work for no benefit.
+    /// </summary>
+    public class ReflectionCallSiteParser
+    {
+        private readonly bool _verbose;
+
+        /// <summary>
+        /// Reflection builder-chain method names we look for as the
+        /// CallExpr's callee. Mirrors AZ::BehaviorContext's
+        /// ClassBuilder/EBusBuilder/GlobalMethodBuilder fluent API
+        /// surface (Method, Property, Constructor, Event) - see
+        /// AzCore/RTTI/BehaviorContext.h. "Attribute" is deliberately
+        /// excluded: it doesn't reflect a callable.
+        /// </summary>
+        private static readonly HashSet<string> ReflectionBuilderMethodNames = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "Method", "Property", "Constructor", "Event",
+        };
+
+        public ReflectionCallSiteParser(bool verbose = false)
+        {
+            _verbose = verbose;
+        }
+
+        /// <summary>
+        /// Single-file convenience wrapper over
+        /// <see cref="ParseReflectionSources"/> for callers (and tests)
+        /// that only have one reflection .cpp in hand and don't need a
+        /// gem name for the progress log.
+        /// </summary>
+        public ReflectionCallSiteResult ParseFile(
+            string path, IEnumerable<string> includePaths, IEnumerable<string> defines)
+        {
+            return ParseReflectionSources(
+                new List<string> { path },
+                new List<string>(includePaths),
+                new List<string>(defines),
+                gemName: Path.GetFileNameWithoutExtension(path));
+        }
+
+        /// <summary>
+        /// Parse a gem's reflection .cpp files and recover call sites.
+        /// </summary>
+        /// <param name="reflectionCppFiles">
+        /// .cpp files known (by convention/config - see
+        /// BindingConfig's ReflectionSources list, or a naming heuristic
+        /// such as "*Component.cpp"/"*System.cpp" containing a
+        /// ReflectContext-taking Reflect method) to contain
+        /// BehaviorContext reflection calls.
+        /// </param>
+        public ReflectionCallSiteResult ParseReflectionSources(
+            List<string> reflectionCppFiles, List<string> includePaths, List<string> defines, string gemName)
+        {
+            var result = new ReflectionCallSiteResult { GemName = gemName };
+
+            if (reflectionCppFiles.Count == 0)
+            {
+                Console.WriteLine($"  [{gemName}] No reflection .cpp files to parse for call-site recovery");
+                return result;
+            }
+
+            Console.WriteLine($"  [{gemName}] Recovering native symbols from {reflectionCppFiles.Count} reflection .cpp file(s)...");
+
+            var args = new List<string>();
+            foreach (var includePath in includePaths) args.Add($"-I{includePath}");
+            foreach (var define in defines) args.Add($"-D{define}");
+            args.Add("-std=c++20");
+            args.Add("-xc++");
+            args.Add("-Wno-pragma-once-outside-header");
+            args.Add("-ferror-limit=0");
+            args.Add("-Wno-everything");
+            args.Add("-fms-extensions");
+            args.Add("-fms-compatibility");
+            args.Add("-fms-compatibility-version=19.40");
+            args.Add("--target=x86_64-pc-windows-msvc");
+            args.Add("-include"); args.Add("climits");
+            args.Add("-include"); args.Add("cstddef");
+            args.Add("-include"); args.Add("cstdint");
+            // Unlike O3DEHeaderParser we deliberately do NOT pass
+            // CXTranslationUnit_SkipFunctionBodies below - the whole
+            // point of this parser is to walk INSIDE Reflect()'s
+            // function body to find the Method(...)/Event(...) call
+            // expressions, which SkipFunctionBodies would elide.
+            var clangArgs = args.ToArray();
+
+            foreach (var cppFile in reflectionCppFiles)
+            {
+                try
+                {
+                    ParseOneFile(cppFile, clangArgs, result);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"  [{gemName}] Error recovering call sites from {cppFile}: {ex.Message}");
+                    if (_verbose) Console.WriteLine(ex.StackTrace);
+                }
+            }
+
+            Console.WriteLine($"  [{gemName}] Recovered {result.RawCallSites.Count} reflection call site(s) " +
+                $"({CountWithSymbol(result)} with a resolved native symbol)");
+
+            return result;
+        }
+
+        private static int CountWithSymbol(ReflectionCallSiteResult result)
+        {
+            int n = 0;
+            foreach (var cs in result.RawCallSites)
+            {
+                if (cs.IsPlainMemberPointer) n++;
+            }
+            return n;
+        }
+
+        private unsafe void ParseOneFile(string cppFile, string[] clangArgs, ReflectionCallSiteResult result)
+        {
+            if (!File.Exists(cppFile))
+            {
+                Console.WriteLine($"Warning: Reflection source not found: {cppFile}");
+                return;
+            }
+
+            using var index = CXIndex.Create();
+            var error = CXTranslationUnit.TryParse(
+                index, cppFile, clangArgs, Array.Empty<CXUnsavedFile>(),
+                CXTranslationUnit_Flags.CXTranslationUnit_None, // keep function bodies
+                out var tu);
+
+            if (error != CXErrorCode.CXError_Success)
+            {
+                Console.WriteLine($"Failed to parse {cppFile}: {error}");
+                return;
+            }
+
+            using (tu)
+            {
+                void Walk(CXCursor cursor)
+                {
+                    if (cursor.Kind == CXCursorKind.CXCursor_CallExpr)
+                    {
+                        var calleeName = GetCallExprMethodName(cursor);
+                        if (calleeName != null && ReflectionBuilderMethodNames.Contains(calleeName))
+                        {
+                            var site = ExtractCallSite(cursor, calleeName, cppFile);
+                            if (site != null)
+                            {
+                                var (className, busName) = ResolveChainScope(cursor);
+                                site.OwningClassName = className;
+                                site.EnclosingBusName = busName;
+                                result.RawCallSites.Add(site);
+                            }
+                        }
+                    }
+
+                    cursor.VisitChildren((child, parent, clientData) =>
+                    {
+                        Walk(child);
+                        return CXChildVisitResult.CXChildVisit_Continue;
+                    }, default(CXClientData));
+                }
+
+                Walk(tu.Cursor);
+
+                // Second pass: mark same-class/same-name duplicates as
+                // LooksOverloaded. This is a same-gem, same-parse-batch
+                // heuristic only (the manifest-level classifier in
+                // NativeBindingGenerator.cs does the authoritative,
+                // cross-gem check against the live BehaviorContext's
+                // m_overload chain) - it exists so a single-file quick
+                // scan already reports a reasonable answer without
+                // waiting for the join.
+                var seen = new Dictionary<string, int>(StringComparer.Ordinal);
+                foreach (var site in result.RawCallSites)
+                {
+                    var key = site.OwningClassName + "::" + site.ReflectedName;
+                    seen.TryGetValue(key, out var count);
+                    seen[key] = count + 1;
+                }
+                foreach (var site in result.RawCallSites)
+                {
+                    var key = site.OwningClassName + "::" + site.ReflectedName;
+                    if (seen.TryGetValue(key, out var count) && count > 1)
+                    {
+                        site.LooksOverloaded = true;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Extract a single Method/Property/Event/Constructor call site:
+        /// the reflected name (first string-literal argument) and the
+        /// native symbol (second argument, if a plain &amp;Symbol form).
+        /// </summary>
+        private unsafe ReflectionCallSite? ExtractCallSite(CXCursor callExpr, string kind, string sourceFile)
+        {
+            var args = GetCallArgs(callExpr);
+            if (args.Count == 0)
+            {
+                return null;
+            }
+
+            var site = new ReflectionCallSite
+            {
+                ReflectionKind = kind,
+                SourceFile = sourceFile,
+                SourceLine = GetLine(callExpr),
+            };
+
+            // First argument: the reflected/script name string literal.
+            // Constructor(...) has no name argument (it's always
+            // positional args only) - falls back to "Constructor" as a
+            // synthetic reflected name, matching
+            // BehaviorContextReflector::ReflectClass's
+            // "Constructor_%d"-style synthesis for the runtime side (kept
+            // simple here; the join in NativeBindingGenerator.cs handles
+            // constructors as a special case rather than joining on name).
+            if (kind == "Constructor")
+            {
+                site.ReflectedName = "Constructor";
+            }
+            else
+            {
+                var nameArg = args[0];
+                var literal = GetStringLiteralValue(nameArg);
+                if (literal == null)
+                {
+                    // Not a literal string - can't safely recover a stable
+                    // reflected name (e.g. a computed/format string). Skip;
+                    // this call site simply won't appear in the manifest
+                    // join and any matching runtime entry stays
+                    // NonBindableReason::NoNativeSideCounterpart, the
+                    // conservative default.
+                    return null;
+                }
+                site.ReflectedName = literal;
+            }
+
+            // Second argument (first for Constructor): the &Class::Method
+            // (or &FreeFunction) expression.
+            int symbolArgIndex = kind == "Constructor" ? 0 : 1;
+            if (args.Count > symbolArgIndex)
+            {
+                var (symbol, isPlain) = ClassifyMethodArgument(args[symbolArgIndex]);
+                site.NativeQualifiedSymbol = symbol ?? string.Empty;
+                site.IsPlainMemberPointer = isPlain;
+            }
+
+            return site;
+        }
+
+        /// <summary>
+        /// Determine whether a reflection call's callable argument is a
+        /// plain <c>&amp;Qualified::Symbol</c> expression (UnaryOperator
+        /// '&amp;' wrapping a DeclRefExpr/MemberExpr/OverloadExpr that
+        /// names a function or method), and if so, return its fully-
+        /// qualified spelling. Anything else (a lambda's CXXConstructExpr/
+        /// LambdaExpr, a call to construct an AZStd::function, a
+        /// non-address expression) returns (null, false) - the "reflected
+        /// via lambda/wrapper" case.
+        /// </summary>
+        private static unsafe (string? symbol, bool isPlain) ClassifyMethodArgument(CXCursor argExpr)
+        {
+            var inner = UnwrapImplicitAndParens(argExpr);
+
+            // static_cast<...>(&Class::Method) overload-disambiguation
+            // form: unwrap the cast to look at what's underneath, but we
+            // do NOT attempt to parse the cast's target type here (see
+            // class doc's Scope/Limitations) - LooksOverloaded is the
+            // signal for this case, not a parsed parameter list.
+            if (inner.Kind == CXCursorKind.CXCursor_CStyleCastExpr ||
+                inner.Kind == CXCursorKind.CXCursor_UnexposedExpr)
+            {
+                // CXCursor_UnexposedExpr is libclang's catch-all for
+                // implicit casts / functional-style casts that don't have
+                // a dedicated cursor kind; recurse into its single child
+                // if present.
+                var child = FirstChild(inner);
+                if (child.HasValue)
+                {
+                    inner = UnwrapImplicitAndParens(child.Value);
+                }
+            }
+
+            if (inner.Kind == CXCursorKind.CXCursor_UnaryOperator)
+            {
+                // Confirm the operator is address-of ('&'). libclang's
+                // CXCursor doesn't expose the operator token directly in
+                // the stable API without tokenizing, so we check via the
+                // cursor's spelling range's first token as a best-effort;
+                // if tokenization is unavailable we still proceed (nearly
+                // every UnaryOperator wrapping a DeclRefExpr/MemberExpr in
+                // this position IS address-of - reflection call sites
+                // don't pass `*ptr` or `-value` as callables) but flag it
+                // less confidently by still requiring the child to be a
+                // reference to a function/method decl below.
+                var child = FirstChild(inner);
+                if (child.HasValue)
+                {
+                    var target = UnwrapImplicitAndParens(child.Value);
+                    var qualifiedName = TryGetReferencedFunctionQualifiedName(target);
+                    if (qualifiedName != null)
+                    {
+                        return (qualifiedName, true);
+                    }
+                }
+                return (null, false);
+            }
+
+            // Free functions can also be reflected as a bare function
+            // name (no explicit '&') in some O3DE call sites - the
+            // implicit function-to-pointer decay means there's no
+            // UnaryOperator node at all, just a DeclRefExpr directly.
+            {
+                var qualifiedName = TryGetReferencedFunctionQualifiedName(inner);
+                if (qualifiedName != null)
+                {
+                    return (qualifiedName, true);
+                }
+            }
+
+            return (null, false);
+        }
+
+        private static unsafe string? TryGetReferencedFunctionQualifiedName(CXCursor cursor)
+        {
+            // DeclRefExpr (free function) or MemberExpr / unexposed member-
+            // pointer forms (member function). In both cases the
+            // referenced cursor's own USR/qualified spelling gives us the
+            // qualified name; clang.getCursorReferenced resolves through
+            // to the actual FunctionDecl/CXXMethodDecl.
+            if (cursor.Kind != CXCursorKind.CXCursor_DeclRefExpr &&
+                cursor.Kind != CXCursorKind.CXCursor_MemberRefExpr &&
+                cursor.Kind != CXCursorKind.CXCursor_OverloadedDeclRef &&
+                cursor.Kind != CXCursorKind.CXCursor_UnexposedExpr)
+            {
+                return null;
+            }
+
+            var referenced = clang.getCursorReferenced(cursor);
+            if (referenced.Kind == CXCursorKind.CXCursor_FunctionDecl ||
+                referenced.Kind == CXCursorKind.CXCursor_CXXMethod ||
+                referenced.Kind == CXCursorKind.CXCursor_Constructor)
+            {
+                return BuildQualifiedName(referenced);
+            }
+
+            // OverloadedDeclRef (name resolves to more than one candidate
+            // at this point in the AST, e.g. before overload resolution
+            // has picked one) - can't get a single qualified name back
+            // reliably. This case flows into LooksOverloaded via the
+            // duplicate-name scan instead.
+            return null;
+        }
+
+        private static string BuildQualifiedName(CXCursor decl)
+        {
+            var parts = new List<string> { decl.Spelling.ToString() };
+            var parent = decl.SemanticParent;
+            while (parent.Kind == CXCursorKind.CXCursor_ClassDecl ||
+                   parent.Kind == CXCursorKind.CXCursor_StructDecl ||
+                   parent.Kind == CXCursorKind.CXCursor_Namespace ||
+                   parent.Kind == CXCursorKind.CXCursor_ClassTemplate)
+            {
+                var name = parent.Spelling.ToString();
+                if (!string.IsNullOrEmpty(name))
+                {
+                    parts.Insert(0, name);
+                }
+                parent = parent.SemanticParent;
+            }
+            return string.Join("::", parts);
+        }
+
+        private static unsafe CXCursor UnwrapImplicitAndParens(CXCursor cursor)
+        {
+            var current = cursor;
+            // ImplicitCastExpr / ParenExpr both show up as
+            // CXCursor_UnexposedExpr in libclang's stable cursor kinds
+            // most of the time; peel through single-child wrappers until
+            // we hit something with either 0 or >1 children, or a kind we
+            // recognize as terminal.
+            for (int i = 0; i < 8; i++) // bounded - reflection call sites are not deeply nested
+            {
+                if (current.Kind == CXCursorKind.CXCursor_UnexposedExpr ||
+                    current.Kind == CXCursorKind.CXCursor_ParenExpr)
+                {
+                    var child = FirstChild(current);
+                    if (child.HasValue)
+                    {
+                        current = child.Value;
+                        continue;
+                    }
+                }
+                break;
+            }
+            return current;
+        }
+
+        private static unsafe CXCursor? FirstChild(CXCursor cursor)
+        {
+            CXCursor? result = null;
+            cursor.VisitChildren((child, parent, clientData) =>
+            {
+                result = child;
+                return CXChildVisitResult.CXChildVisit_Break;
+            }, default(CXClientData));
+            return result;
+        }
+
+        private static unsafe List<CXCursor> GetCallArgs(CXCursor callExpr)
+        {
+            // CXCursor_CallExpr's children are: [calleeExpr, arg0, arg1, ...]
+            // for a plain call, or just [arg0, arg1, ...] with the callee
+            // folded into CXCursor_MemberRefExpr for `->Method(a, b)`
+            // chains (the "callee" is itself the MemberRefExpr child, and
+            // its OWN children are the object expression - i.e. the rest
+            // of the chain - so we can't just skip "child 0" blindly).
+            // We instead collect every child, then drop the first child
+            // IF it is a callee-shaped node (MemberRefExpr / DeclRefExpr /
+            // UnexposedExpr wrapping either) - everything else is a real
+            // argument.
+            var children = new List<CXCursor>();
+            callExpr.VisitChildren((child, parent, clientData) =>
+            {
+                children.Add(child);
+                return CXChildVisitResult.CXChildVisit_Continue;
+            }, default(CXClientData));
+
+            if (children.Count == 0)
+            {
+                return children;
+            }
+
+            var first = UnwrapImplicitAndParens(children[0]);
+            bool firstIsCallee =
+                first.Kind == CXCursorKind.CXCursor_MemberRefExpr ||
+                first.Kind == CXCursorKind.CXCursor_DeclRefExpr ||
+                first.Kind == CXCursorKind.CXCursor_UnexposedExpr;
+
+            return firstIsCallee ? children.GetRange(1, children.Count - 1) : children;
+        }
+
+        private static unsafe string? GetCallExprMethodName(CXCursor callExpr)
+        {
+            var children = new List<CXCursor>();
+            callExpr.VisitChildren((child, parent, clientData) =>
+            {
+                children.Add(child);
+                return CXChildVisitResult.CXChildVisit_Break; // only need the first (callee)
+            }, default(CXClientData));
+
+            if (children.Count == 0)
+            {
+                return null;
+            }
+
+            var callee = UnwrapImplicitAndParens(children[0]);
+            if (callee.Kind == CXCursorKind.CXCursor_MemberRefExpr)
+            {
+                return callee.Spelling.ToString();
+            }
+            if (callee.Kind == CXCursorKind.CXCursor_DeclRefExpr)
+            {
+                return callee.Spelling.ToString();
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Recovers the (className, busName) scope a Method/Property/
+        /// Event/Constructor call site belongs to.
+        ///
+        /// A fluent chain <c>ctx-&gt;Class&lt;T&gt;("Name")-&gt;Method(...)</c>
+        /// puts the LATER call (Method) as the AST ANCESTOR and the
+        /// EARLIER call (Class) as its DESCENDANT: Method's callee is a
+        /// MemberRefExpr "Method" whose own child is the base object
+        /// expression - which is the Class(...) CallExpr. That is the
+        /// opposite of what a naive pre-order "push scope on the way down,
+        /// pop on the way back up" traversal assumes (which would only
+        /// see Class as an ancestor of Method, never the reverse) - a
+        /// stack built that way never has anything on it by the time a
+        /// chained ->Method() call is reached, because Class() lives
+        /// deeper in the tree, not further up it.
+        ///
+        /// So instead of a traversal-order stack, this walks DOWN from the
+        /// call site itself through each MemberRefExpr callee's base
+        /// object, hopping from one CallExpr to the next earlier one in
+        /// the chain, until it finds the Class&lt;T&gt;(...) or
+        /// EBus&lt;T&gt;::Behavior(...)/Handler(...) root (or runs out of
+        /// chain, e.g. a bare BehaviorContext::Method(...) at namespace
+        /// scope, which correctly yields no scope).
+        /// </summary>
+        private static unsafe (string ClassName, string BusName) ResolveChainScope(CXCursor callExpr)
+        {
+            var current = callExpr;
+
+            for (int i = 0; i < 32; i++) // bounded - reflection chains are not deeply nested
+            {
+                var children = new List<CXCursor>();
+                current.VisitChildren((child, parent, clientData) =>
+                {
+                    children.Add(child);
+                    return CXChildVisitResult.CXChildVisit_Break; // only need the callee
+                }, default(CXClientData));
+
+                if (children.Count == 0)
+                {
+                    return (string.Empty, string.Empty);
+                }
+
+                var callee = UnwrapImplicitAndParens(children[0]);
+                if (callee.Kind != CXCursorKind.CXCursor_MemberRefExpr)
+                {
+                    // Free function call, or we've reached the raw
+                    // BehaviorContext pointer itself - no chain object
+                    // left to inspect, so no enclosing scope.
+                    return (string.Empty, string.Empty);
+                }
+
+                var calleeName = callee.Spelling.ToString();
+                if (calleeName == "Class")
+                {
+                    var className = GetFirstTemplateArgTypeName(current) ?? GetFirstStringLiteralArg(current);
+                    return (className ?? string.Empty, string.Empty);
+                }
+                if (calleeName == "Behavior" || calleeName == "Handler")
+                {
+                    var busName = GetFirstTemplateArgTypeName(current);
+                    return (string.Empty, busName ?? string.Empty);
+                }
+
+                // Any other chain link (Method/Property/Event/Attribute/...
+                // chained before this one) - hop to the object it was
+                // called on and keep looking for the chain's root.
+                var baseExpr = FirstChild(callee);
+                if (!baseExpr.HasValue)
+                {
+                    return (string.Empty, string.Empty);
+                }
+
+                var baseUnwrapped = UnwrapImplicitAndParens(baseExpr.Value);
+                if (baseUnwrapped.Kind != CXCursorKind.CXCursor_CallExpr)
+                {
+                    return (string.Empty, string.Empty);
+                }
+
+                current = baseUnwrapped;
+            }
+
+            return (string.Empty, string.Empty);
+        }
+
+        private static unsafe string? GetFirstTemplateArgTypeName(CXCursor callExpr)
+        {
+            // For Class<T>("Name") / EBus<TBus>::Behavior(...), the
+            // template argument type is attached to the callee's
+            // ReferencedType; walk the callee's DeclRefExpr and read its
+            // type's template-argument-0 spelling. libclang's stable API
+            // exposes this through clang.Type_getNumTemplateArguments /
+            // Type_getTemplateArgumentAsType on the callee cursor's type
+            // when available; fall back to null (caller then tries the
+            // string-literal heuristic instead) since not every clang
+            // build exposes template-argument introspection uniformly.
+            try
+            {
+                var children = new List<CXCursor>();
+                callExpr.VisitChildren((child, parent, clientData) =>
+                {
+                    children.Add(child);
+                    return CXChildVisitResult.CXChildVisit_Break;
+                }, default(CXClientData));
+                if (children.Count == 0) return null;
+
+                var callee = UnwrapImplicitAndParens(children[0]);
+                var referenced = clang.getCursorReferenced(callee);
+                var type = referenced.Type;
+                if (type.NumTemplateArguments > 0)
+                {
+                    var argType = clang.Type_getTemplateArgumentAsType(type, 0);
+                    var name = argType.Spelling.ToString();
+                    return string.IsNullOrEmpty(name) ? null : name;
+                }
+            }
+            catch
+            {
+                // Best-effort only - see method doc.
+            }
+            return null;
+        }
+
+        private static unsafe string? GetFirstStringLiteralArg(CXCursor callExpr)
+        {
+            var args = GetCallArgs(callExpr);
+            return args.Count > 0 ? GetStringLiteralValue(args[0]) : null;
+        }
+
+        private static unsafe string? GetStringLiteralValue(CXCursor cursor)
+        {
+            var inner = UnwrapImplicitAndParens(cursor);
+            if (inner.Kind == CXCursorKind.CXCursor_StringLiteral)
+            {
+                var spelling = inner.Spelling.ToString();
+                // libclang's Spelling for a StringLiteral is the raw
+                // source token including quotes, e.g. "\"GetLength\"" -
+                // strip the surrounding quotes.
+                if (spelling.Length >= 2 && spelling[0] == '"' && spelling[^1] == '"')
+                {
+                    return spelling.Substring(1, spelling.Length - 2);
+                }
+                return spelling;
+            }
+            return null;
+        }
+
+        private static unsafe uint GetLine(CXCursor cursor)
+        {
+            var loc = cursor.Location;
+            CXFile file;
+            uint line, column, offset;
+            clang.getFileLocation(loc, (void**)&file, &line, &column, &offset);
+            return line;
+        }
+    }
+}

--- a/Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Program.cs
+++ b/Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Program.cs
@@ -12,9 +12,11 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using O3DESharp.BindingGenerator.Configuration;
 using O3DESharp.BindingGenerator.GemDiscovery;
 using O3DESharp.BindingGenerator.Generation;
+using O3DESharp.BindingGenerator.Parsing;
 
 namespace O3DESharp.BindingGenerator
 {
@@ -199,9 +201,46 @@ namespace O3DESharp.BindingGenerator
                 context.ExitCode = 0;
             });
 
+            // native-bindings command - joins the C++ runtime manifest
+            // (native symbol column empty, see NativeBindingManifestSchema)
+            // against libclang-recovered call sites and writes the bound
+            // manifest. SP-1b-1 offline half only - see plan/spec for the
+            // runtime half (SP-1b-2) that actually dispatches through it.
+            var nativeManifestOption = new Option<string>(
+                aliases: new[] { "--manifest" },
+                description: "Path to the native-binding manifest JSON emitted by the C++ runtime pass.")
+            { IsRequired = true };
+
+            var nativeReflectionSourcesOption = new Option<string>(
+                aliases: new[] { "--reflection-sources" },
+                description: "Reflection .cpp file, directory (searched recursively for *.cpp), or glob pattern to recover native symbols from.")
+            { IsRequired = true };
+
+            var nativeOutputOption = new Option<string>(
+                aliases: new[] { "--output" },
+                description: "Where to write the joined manifest JSON.")
+            { IsRequired = true };
+
+            var nativeBindingsCommand = new Command(
+                "native-bindings",
+                "Join a native-binding manifest against libclang-recovered reflection call sites and emit the bound manifest");
+            nativeBindingsCommand.AddOption(nativeManifestOption);
+            nativeBindingsCommand.AddOption(nativeReflectionSourcesOption);
+            nativeBindingsCommand.AddOption(nativeOutputOption);
+            nativeBindingsCommand.AddOption(verboseOption);
+            nativeBindingsCommand.SetHandler((context) =>
+            {
+                var manifestPath = context.ParseResult.GetValueForOption(nativeManifestOption)!;
+                var reflectionSources = context.ParseResult.GetValueForOption(nativeReflectionSourcesOption)!;
+                var outputPath = context.ParseResult.GetValueForOption(nativeOutputOption)!;
+                var verbose = context.ParseResult.GetValueForOption(verboseOption);
+                context.ExitCode = RunNativeBindings(manifestPath, reflectionSources, outputPath, verbose);
+            });
+
             rootCommand.AddCommand(listGemsCommand);
             rootCommand.AddCommand(generateCommand);
             rootCommand.AddCommand(initConfigCommand);
+            rootCommand.AddCommand(nativeBindingsCommand);
 
             // Default action is generate
             rootCommand.AddOption(projectOption);
@@ -483,6 +522,122 @@ namespace O3DESharp.BindingGenerator
                 }
                 return 1;
             }
+        }
+
+        /// <summary>
+        /// native-bindings verb: loads the C++ runtime's manifest (native
+        /// symbol column empty), recovers &amp;C::Method symbols from the
+        /// gem's reflection .cpp files via ReflectionCallSiteParser, joins
+        /// them with NativeBindingJoin.Apply, and writes the bound
+        /// manifest. Pure orchestration - all the classification logic
+        /// lives in NativeBindingJoin (Task 2) and is unit-tested there.
+        /// </summary>
+        static int RunNativeBindings(string manifestPath, string reflectionSourcesPath, string outputPath, bool verbose)
+        {
+            try
+            {
+                Console.WriteLine("O3DE C# Binding Generator - native-bindings");
+                Console.WriteLine("=============================================\n");
+
+                if (!File.Exists(manifestPath))
+                {
+                    Console.WriteLine($"Error: manifest not found: {manifestPath}");
+                    return 1;
+                }
+
+                var manifest = JsonSerializer.Deserialize<NativeBindingManifestDocument>(File.ReadAllText(manifestPath));
+                if (manifest == null)
+                {
+                    Console.WriteLine($"Error: failed to parse manifest: {manifestPath}");
+                    return 1;
+                }
+
+                var reflectionCppFiles = ResolveReflectionSources(reflectionSourcesPath);
+
+                Console.WriteLine($"Manifest:           {manifestPath} ({manifest.Methods.Count} methods)");
+                Console.WriteLine($"Reflection sources: {reflectionSourcesPath} ({reflectionCppFiles.Count} file(s))");
+                Console.WriteLine($"Output:             {outputPath}\n");
+
+                var parser = new ReflectionCallSiteParser(verbose);
+                var callSites = new List<CallSiteSymbol>();
+                foreach (var cppFile in reflectionCppFiles)
+                {
+                    var parsed = parser.ParseFile(cppFile, Array.Empty<string>(), Array.Empty<string>());
+                    callSites.AddRange(parsed.CallSites);
+                }
+
+                var report = NativeBindingJoin.Apply(manifest, callSites);
+
+                // Printed unconditionally, not gated on --verbose: a run
+                // that binds nothing is exactly the case a user most needs
+                // told about, and would otherwise look identical to a
+                // successful run that simply had nothing to bind.
+                Console.WriteLine("========== Join Report ==========");
+                Console.WriteLine($"Total:   {report.Total}");
+                Console.WriteLine($"Bound:   {report.Bound}");
+                Console.WriteLine($"Unbound: {report.Unbound}");
+                if (report.ReasonCounts.Count > 0)
+                {
+                    Console.WriteLine("Reasons:");
+                    foreach (var reason in report.ReasonCounts.OrderByDescending(r => r.Value).ThenBy(r => r.Key, StringComparer.Ordinal))
+                    {
+                        Console.WriteLine($"  {reason.Key,-24} {reason.Value}");
+                    }
+                }
+                Console.WriteLine();
+
+                var outputDir = Path.GetDirectoryName(Path.GetFullPath(outputPath));
+                if (!string.IsNullOrEmpty(outputDir))
+                {
+                    Directory.CreateDirectory(outputDir);
+                }
+                File.WriteAllText(outputPath, JsonSerializer.Serialize(manifest));
+                Console.WriteLine($"Wrote joined manifest: {outputPath}");
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+                if (verbose)
+                {
+                    Console.WriteLine(ex.StackTrace);
+                }
+                return 1;
+            }
+        }
+
+        /// <summary>
+        /// Resolves --reflection-sources to a concrete file list: a single
+        /// .cpp file used as-is, a directory searched recursively for
+        /// *.cpp, or a simple (non-recursive) glob against its parent
+        /// directory (e.g. "Source/*Component.cpp"). No "**" support here
+        /// - reflection .cpp files live in one gem's Source tree by O3DE
+        /// convention, so a directory search already covers the common
+        /// case without needing MultiGemBindingGenerator's full
+        /// multi-segment glob resolver.
+        /// </summary>
+        static List<string> ResolveReflectionSources(string path)
+        {
+            if (Directory.Exists(path))
+            {
+                return Directory.EnumerateFiles(path, "*.cpp", SearchOption.AllDirectories).ToList();
+            }
+
+            if (File.Exists(path))
+            {
+                return new List<string> { path };
+            }
+
+            var dir = Path.GetDirectoryName(path);
+            var pattern = Path.GetFileName(path);
+            if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir) && !string.IsNullOrEmpty(pattern))
+            {
+                return Directory.GetFiles(dir, pattern, SearchOption.TopDirectoryOnly).ToList();
+            }
+
+            Console.WriteLine($"Warning: --reflection-sources path not found: {path}");
+            return new List<string>();
         }
     }
 }

--- a/docs/superpowers/plans/2026-07-15-sp1b1-native-binding-manifest-offline.md
+++ b/docs/superpowers/plans/2026-07-15-sp1b1-native-binding-manifest-offline.md
@@ -1,0 +1,864 @@
+# SP-1b-1 Native Binding Manifest — Offline Half — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce the build-time artifact that AOT's static dispatch needs — a manifest of every BehaviorContext method that can be called as a direct native trampoline, joined to its real C++ symbol, plus the generated trampolines themselves.
+
+**Architecture:** `BehaviorContext` cannot yield a native C++ symbol at runtime (its functor type-erases the pointer inside an `AZStd::function`), so the manifest is built by two independent passes joined offline: a C++ runtime pass emits the runtime-observable half as JSON, and a libclang pass over each gem's reflection `.cpp` recovers `&C::Method` from `->Method("name", &C::Method)`. This plan implements the **offline (C#) half only** — schema, parser, join, classifier, emission — all of which is fully testable without an engine.
+
+**Tech Stack:** C# / .NET 9, `System.Text.Json`, ClangSharp (win-x64), xUnit + FluentAssertions.
+
+## Global Constraints
+
+- **This is the offline half only.** The runtime half — `BindingRegistry`, load-time manifest validation, the dispatch hook, differential testing — is **SP-1b-2** and must not start here. Per the SP-1 spec it is additionally gated on SP-1a's C++ being proven in a real engine build, which has not happened.
+- **Everything in this plan is verifiable in the development environment.** Unlike the SP-1a and M2 C++, there is no "not compile-verified" escape hatch — if a task cannot be demonstrated green, it is not done.
+- **Source material is unfinished.** The rescued files under `Rescued/1b-native-trampoline/` (branch `feat/1b-native-trampoline-rescue`, `8a00627`) have **never been compiled**. Treat them as a strong starting point for *analysis and structure*, not as code to paste unchanged. Expect to fix them.
+- **The classifier stays conservative.** v1 refuses `Overloaded`, `ReflectedViaLambda`, `OnDemandTemplateType`, `EBusAddressedById`, `UnresolvedNativeSymbol`, `UnsupportedArgStorage`, `NoNativeSideCounterpart`. Widening the bound set is a later, evidence-driven change — never a convenience during implementation.
+- **A wrong binding is worse than no binding.** Every ambiguity resolves toward *not* binding. An unbound method falls back to `BehaviorMethod::Call` and costs speed; a mis-bound one calls a function pointer with the wrong signature and corrupts memory.
+- Artifacts are generated on Windows and committed (SP-1 spec §6.3), so Linux/CI consume them without libclang.
+- Commit messages must contain **no** Claude/Anthropic co-author or attribution trailers.
+
+## The contract (already written, verified)
+
+`NativeBindingManifestSchema.cs` in the rescued tree defines the C++↔C# interface and is complete. Key fields, and which side owns them:
+
+| Field | Emitted by C++ runtime pass | Filled by this plan's offline join |
+|---|---|---|
+| `reflected_name`, `owning_class_*`, `is_static`, `is_const` | ✅ | — |
+| `return`, `arguments` (with `storage_class`, `type_id`, `size_bytes`, `align_bytes`) | ✅ | — |
+| `native_qualified_symbol` | ❌ always empty — **cannot** be recovered at runtime | ✅ from the libclang pass |
+| `bindable`, `non_bindable_reason` | ❌ always `false` / `NoNativeSideCounterpart` | ✅ from the classifier |
+| `binding_id` | ✅ | — (stable key used by the runtime registry) |
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Configuration/NativeBindingManifestSchema.cs` | DTOs for the manifest JSON. Pure data; no logic. |
+| `.../Parsing/ReflectionCallSiteParser.cs` | libclang pass: recover `(className, reflectedName) -> &C::Method` from reflection `.cpp` files. |
+| `.../Generation/NativeBindingJoin.cs` (new) | The join + classifier. Pure, no I/O — this is where correctness lives, so it must be trivially testable. |
+| `.../Generation/NativeBindingGenerator.cs` | Orchestration + trampoline emission. |
+| `Code/Tools/BindingGenerator.Tests/NativeBinding*.cs` | Tests for each of the above. |
+
+---
+
+### Task 1: Manifest schema + round-trip tests
+
+**Files:**
+- Create: `Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Configuration/NativeBindingManifestSchema.cs`
+- Test: `Code/Tools/BindingGenerator.Tests/NativeBindingManifestSchemaTests.cs`
+
+**Interfaces:**
+- Produces: `NativeBindingManifestDocument` { `Methods: List<NativeBindingManifestMethod>` }, `NativeBindingManifestMethod`, `NativeBindingManifestArgument` — all with `[JsonPropertyName]` snake_case names exactly as in the rescued file.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Code/Tools/BindingGenerator.Tests/NativeBindingManifestSchemaTests.cs`:
+
+```csharp
+//
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// For complete copyright and license terms please see the LICENSE at the root of this distribution.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+using System.Text.Json;
+using O3DESharp.BindingGenerator.Configuration;
+
+namespace O3DESharp.BindingGenerator.Tests;
+
+/// <summary>
+/// The manifest JSON is the contract between the C++ exporter
+/// (NativeBindingManifestExporter) and this generator. The property names are
+/// the wire format: renaming one silently produces a manifest where every
+/// method looks unbindable, which degrades to the slow path rather than
+/// failing loudly. These pin the names.
+/// </summary>
+public class NativeBindingManifestSchemaTests
+{
+    private const string SampleJson = """
+    {
+      "methods": [
+        {
+          "reflected_name": "GetLength",
+          "owning_class_name": "Vector3",
+          "owning_class_type_id": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+          "owning_class_size_bytes": 16,
+          "owning_class_align_bytes": 16,
+          "is_static": false,
+          "is_const": true,
+          "native_qualified_symbol": "",
+          "return": {
+            "name": "", "cpp_type_name": "float", "type_id": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+            "storage_class": "Value", "size_bytes": 4, "align_bytes": 4
+          },
+          "arguments": [],
+          "bindable": false,
+          "non_bindable_reason": "NoNativeSideCounterpart",
+          "binding_id": "Vector3::GetLength"
+        }
+      ]
+    }
+    """;
+
+    [Fact]
+    public void Deserializes_TheCppExporterWireFormat()
+    {
+        var doc = JsonSerializer.Deserialize<NativeBindingManifestDocument>(SampleJson);
+
+        doc.Should().NotBeNull();
+        doc!.Methods.Should().ContainSingle();
+
+        var m = doc.Methods[0];
+        m.ReflectedName.Should().Be("GetLength");
+        m.OwningClassName.Should().Be("Vector3");
+        m.OwningClassSizeBytes.Should().Be(16);
+        m.IsConst.Should().BeTrue();
+        m.IsStatic.Should().BeFalse();
+        m.BindingId.Should().Be("Vector3::GetLength");
+        m.Return.CppTypeName.Should().Be("float");
+        m.Return.StorageClass.Should().Be("Value");
+    }
+
+    [Fact]
+    public void CppExporterLeavesTheJoinedFieldsUnset()
+    {
+        // The runtime BehaviorContext pass cannot recover a native symbol and
+        // does not classify. Both are this generator's job; if the exporter
+        // ever starts filling them, the join must be revisited.
+        var doc = JsonSerializer.Deserialize<NativeBindingManifestDocument>(SampleJson)!;
+        var m = doc.Methods[0];
+
+        m.NativeQualifiedSymbol.Should().BeEmpty();
+        m.Bindable.Should().BeFalse();
+        m.NonBindableReason.Should().Be("NoNativeSideCounterpart");
+    }
+
+    [Fact]
+    public void RoundTripsWithoutLosingFields()
+    {
+        var doc = JsonSerializer.Deserialize<NativeBindingManifestDocument>(SampleJson)!;
+        doc.Methods[0].NativeQualifiedSymbol = "AZ::Vector3::GetLength";
+        doc.Methods[0].Bindable = true;
+        doc.Methods[0].NonBindableReason = "None";
+
+        var json = JsonSerializer.Serialize(doc);
+        var again = JsonSerializer.Deserialize<NativeBindingManifestDocument>(json)!;
+
+        again.Methods[0].NativeQualifiedSymbol.Should().Be("AZ::Vector3::GetLength");
+        again.Methods[0].Bindable.Should().BeTrue();
+        again.Methods[0].BindingId.Should().Be("Vector3::GetLength");
+    }
+
+    [Fact]
+    public void EmptyManifestIsValid()
+    {
+        var doc = JsonSerializer.Deserialize<NativeBindingManifestDocument>("""{"methods":[]}""");
+        doc!.Methods.Should().BeEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test Code/Tools/BindingGenerator.Tests/BindingGenerator.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~NativeBindingManifestSchemaTests"`
+Expected: build failure — `NativeBindingManifestDocument` does not exist.
+
+- [ ] **Step 3: Restore the schema**
+
+Copy `Rescued/1b-native-trampoline/Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Configuration/NativeBindingManifestSchema.cs` (from branch `feat/1b-native-trampoline-rescue`) to `Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Configuration/NativeBindingManifestSchema.cs`.
+
+It is pure DTOs and should need no changes — but read it and confirm the `[JsonPropertyName]` values match the test's expectations exactly before assuming so. If any differ, **the rescued file wins** (it is the side that matches the C++ exporter); update the test instead.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test Code/Tools/BindingGenerator.Tests/BindingGenerator.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~NativeBindingManifestSchemaTests"`
+Expected: `Passed! - Failed: 0, Passed: 4`
+
+- [ ] **Step 5: Full suite**
+
+Run: `dotnet test Code/Tools/BindingGenerator.Tests/BindingGenerator.Tests.csproj -c Release --nologo`
+Expected: all pass (prior count + 4).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Configuration/NativeBindingManifestSchema.cs Code/Tools/BindingGenerator.Tests/NativeBindingManifestSchemaTests.cs
+git commit -m "SP-1b-1: restore the native-binding manifest schema with wire-format tests"
+```
+
+---
+
+### Task 2: The join + classifier (pure, no I/O)
+
+**Files:**
+- Create: `Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Generation/NativeBindingJoin.cs`
+- Test: `Code/Tools/BindingGenerator.Tests/NativeBindingJoinTests.cs`
+
+**Interfaces:**
+- Produces (consumed by Tasks 3, 4):
+  - `record CallSiteSymbol(string ClassName, string ReflectedName, string NativeQualifiedSymbol, bool ViaLambda);`
+  - `static JoinReport NativeBindingJoin.Apply(NativeBindingManifestDocument manifest, IReadOnlyCollection<CallSiteSymbol> callSites);`
+  - `record JoinReport(int Total, int Bound, int Unbound, IReadOnlyDictionary<string,int> ReasonCounts);`
+
+> This task is deliberately separated from the libclang parsing and from file I/O. The join is where a mistake silently produces a *wrong* binding, so it must be testable with plain in-memory data and no external dependencies.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Code/Tools/BindingGenerator.Tests/NativeBindingJoinTests.cs`:
+
+```csharp
+//
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// For complete copyright and license terms please see the LICENSE at the root of this distribution.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+using System.Collections.Generic;
+using System.Linq;
+using O3DESharp.BindingGenerator.Configuration;
+using O3DESharp.BindingGenerator.Generation;
+
+namespace O3DESharp.BindingGenerator.Tests;
+
+/// <summary>
+/// The join is the one place a mistake produces a WRONG binding rather than a
+/// missing one. A missing binding falls back to BehaviorMethod::Call and costs
+/// speed; a wrong one calls a function pointer with a mismatched signature.
+/// Every ambiguous case must therefore resolve to "not bindable".
+/// </summary>
+public class NativeBindingJoinTests
+{
+    private static NativeBindingManifestMethod Method(
+        string cls, string name, bool isStatic = false, params string[] argStorageClasses)
+    {
+        return new NativeBindingManifestMethod
+        {
+            ReflectedName = name,
+            OwningClassName = cls,
+            OwningClassTypeId = "{00000000-0000-0000-0000-000000000001}",
+            IsStatic = isStatic,
+            BindingId = $"{cls}::{name}",
+            Return = new NativeBindingManifestArgument { CppTypeName = "void", StorageClass = "Value" },
+            Arguments = argStorageClasses
+                .Select(sc => new NativeBindingManifestArgument { StorageClass = sc, CppTypeName = "int" })
+                .ToList(),
+        };
+    }
+
+    private static NativeBindingManifestDocument Doc(params NativeBindingManifestMethod[] methods)
+        => new() { Methods = methods.ToList() };
+
+    [Fact]
+    public void MatchingCallSite_PopulatesSymbolAndBinds()
+    {
+        var doc = Doc(Method("Vector3", "GetLength"));
+        var sites = new[] { new CallSiteSymbol("Vector3", "GetLength", "AZ::Vector3::GetLength", false) };
+
+        var report = NativeBindingJoin.Apply(doc, sites);
+
+        doc.Methods[0].NativeQualifiedSymbol.Should().Be("AZ::Vector3::GetLength");
+        doc.Methods[0].Bindable.Should().BeTrue();
+        doc.Methods[0].NonBindableReason.Should().Be("None");
+        report.Bound.Should().Be(1);
+    }
+
+    [Fact]
+    public void NoMatchingCallSite_IsUnresolvedNotBound()
+    {
+        var doc = Doc(Method("Vector3", "GetLength"));
+
+        var report = NativeBindingJoin.Apply(doc, System.Array.Empty<CallSiteSymbol>());
+
+        doc.Methods[0].Bindable.Should().BeFalse();
+        doc.Methods[0].NonBindableReason.Should().Be("UnresolvedNativeSymbol");
+        doc.Methods[0].NativeQualifiedSymbol.Should().BeEmpty();
+        report.Bound.Should().Be(0);
+    }
+
+    [Fact]
+    public void SameReflectedNameOnDifferentClasses_DoesNotCrossJoin()
+    {
+        // The join key is (className, reflectedName). If it ever degrades to
+        // reflectedName alone, Transform::GetLength would bind to
+        // AZ::Vector3::GetLength - a wrong pointer with a plausible name.
+        var doc = Doc(Method("Vector3", "GetLength"), Method("Transform", "GetLength"));
+        var sites = new[] { new CallSiteSymbol("Vector3", "GetLength", "AZ::Vector3::GetLength", false) };
+
+        NativeBindingJoin.Apply(doc, sites);
+
+        doc.Methods.Single(m => m.OwningClassName == "Vector3").NativeQualifiedSymbol
+            .Should().Be("AZ::Vector3::GetLength");
+        doc.Methods.Single(m => m.OwningClassName == "Transform").NativeQualifiedSymbol
+            .Should().BeEmpty("Transform::GetLength has no call site and must not inherit Vector3's symbol");
+    }
+
+    [Fact]
+    public void DuplicateCallSitesForSameKey_RefusesToBind()
+    {
+        // Two different &C::Method expressions reflected under one script name
+        // means an overload set. Picking either is a coin flip, so bind neither.
+        var doc = Doc(Method("Vector3", "Set"));
+        var sites = new[]
+        {
+            new CallSiteSymbol("Vector3", "Set", "AZ::Vector3::Set", false),
+            new CallSiteSymbol("Vector3", "Set", "AZ::Vector3::SetFloat3", false),
+        };
+
+        NativeBindingJoin.Apply(doc, sites);
+
+        doc.Methods[0].Bindable.Should().BeFalse();
+        doc.Methods[0].NonBindableReason.Should().Be("Overloaded");
+    }
+
+    [Fact]
+    public void LambdaReflectedCallSite_IsNotBound()
+    {
+        var doc = Doc(Method("Vector3", "Weird"));
+        var sites = new[] { new CallSiteSymbol("Vector3", "Weird", "", true) };
+
+        NativeBindingJoin.Apply(doc, sites);
+
+        doc.Methods[0].Bindable.Should().BeFalse();
+        doc.Methods[0].NonBindableReason.Should().Be("ReflectedViaLambda");
+    }
+
+    [Fact]
+    public void UnknownArgStorageClass_IsNotBound()
+    {
+        var doc = Doc(Method("Vector3", "Odd", false, "Value", "Unknown"));
+        var sites = new[] { new CallSiteSymbol("Vector3", "Odd", "AZ::Vector3::Odd", false) };
+
+        NativeBindingJoin.Apply(doc, sites);
+
+        doc.Methods[0].Bindable.Should().BeFalse();
+        doc.Methods[0].NonBindableReason.Should().Be("UnsupportedArgStorage");
+    }
+
+    [Fact]
+    public void UnknownReturnStorageClass_IsNotBound()
+    {
+        var doc = Doc(Method("Vector3", "OddRet"));
+        doc.Methods[0].Return.StorageClass = "Unknown";
+        doc.Methods[0].Return.CppTypeName = "SomethingExotic";
+        var sites = new[] { new CallSiteSymbol("Vector3", "OddRet", "AZ::Vector3::OddRet", false) };
+
+        NativeBindingJoin.Apply(doc, sites);
+
+        doc.Methods[0].Bindable.Should().BeFalse();
+        doc.Methods[0].NonBindableReason.Should().Be("UnsupportedArgStorage");
+    }
+
+    [Fact]
+    public void VoidReturn_IsBindable()
+    {
+        // "void" carries StorageClass Value but is not a real value - it must
+        // not be mistaken for an unsupported storage class.
+        var doc = Doc(Method("Vector3", "Reset"));
+        var sites = new[] { new CallSiteSymbol("Vector3", "Reset", "AZ::Vector3::Reset", false) };
+
+        NativeBindingJoin.Apply(doc, sites);
+
+        doc.Methods[0].Bindable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Report_CountsReasons()
+    {
+        var doc = Doc(
+            Method("A", "Ok"),
+            Method("B", "Missing"),
+            Method("C", "Lambda"));
+        var sites = new[]
+        {
+            new CallSiteSymbol("A", "Ok", "AZ::A::Ok", false),
+            new CallSiteSymbol("C", "Lambda", "", true),
+        };
+
+        var report = NativeBindingJoin.Apply(doc, sites);
+
+        report.Total.Should().Be(3);
+        report.Bound.Should().Be(1);
+        report.Unbound.Should().Be(2);
+        report.ReasonCounts["UnresolvedNativeSymbol"].Should().Be(1);
+        report.ReasonCounts["ReflectedViaLambda"].Should().Be(1);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test Code/Tools/BindingGenerator.Tests/BindingGenerator.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~NativeBindingJoinTests"`
+Expected: build failure — `NativeBindingJoin` / `CallSiteSymbol` do not exist.
+
+- [ ] **Step 3: Implement**
+
+Create `Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Generation/NativeBindingJoin.cs`:
+
+```csharp
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using O3DESharp.BindingGenerator.Configuration;
+
+namespace O3DESharp.BindingGenerator.Generation
+{
+    /// <summary>One recovered `->Method("name", &amp;C::Method)` reflection call site.</summary>
+    /// <param name="ClassName">Reflected class name, matching the manifest's owning_class_name.</param>
+    /// <param name="ReflectedName">The script-visible name passed to ->Method(...).</param>
+    /// <param name="NativeQualifiedSymbol">e.g. "AZ::Vector3::GetLength". Empty when ViaLambda.</param>
+    /// <param name="ViaLambda">True when the call site passed a lambda/wrapper rather than &amp;C::Method.</param>
+    public sealed record CallSiteSymbol(
+        string ClassName,
+        string ReflectedName,
+        string NativeQualifiedSymbol,
+        bool ViaLambda);
+
+    /// <summary>Aggregate outcome of a join, for logging and coverage assertions.</summary>
+    public sealed record JoinReport(
+        int Total,
+        int Bound,
+        int Unbound,
+        IReadOnlyDictionary<string, int> ReasonCounts);
+
+    /// <summary>
+    /// Joins the C++ runtime manifest against libclang-recovered call sites and
+    /// classifies what may be bound as a native trampoline.
+    ///
+    /// Deliberately pure: no file, no libclang, no engine. The join is the one
+    /// place an error yields a WRONG binding rather than a missing one - calling
+    /// a function pointer with a mismatched signature - so it has to be provable
+    /// with plain in-memory data.
+    ///
+    /// Every ambiguity resolves toward NOT binding. An unbound method falls back
+    /// to BehaviorMethod::Call and merely costs speed.
+    /// </summary>
+    public static class NativeBindingJoin
+    {
+        private const string StorageUnknown = "Unknown";
+
+        public static JoinReport Apply(
+            NativeBindingManifestDocument manifest,
+            IReadOnlyCollection<CallSiteSymbol> callSites)
+        {
+            ArgumentNullException.ThrowIfNull(manifest);
+            ArgumentNullException.ThrowIfNull(callSites);
+
+            // Key on (className, reflectedName). Never on reflectedName alone:
+            // Transform::GetLength and Vector3::GetLength are different methods
+            // that share a script name, and cross-joining them would bind a
+            // plausible-looking but wrong pointer.
+            var byKey = new Dictionary<(string, string), List<CallSiteSymbol>>();
+            foreach (var site in callSites)
+            {
+                var key = (site.ClassName, site.ReflectedName);
+                if (!byKey.TryGetValue(key, out var list))
+                {
+                    list = new List<CallSiteSymbol>();
+                    byKey[key] = list;
+                }
+                list.Add(site);
+            }
+
+            var reasons = new Dictionary<string, int>();
+            int bound = 0;
+
+            foreach (var method in manifest.Methods)
+            {
+                var reason = Classify(method, byKey, out string symbol);
+
+                if (reason == "None")
+                {
+                    method.NativeQualifiedSymbol = symbol;
+                    method.Bindable = true;
+                    method.NonBindableReason = "None";
+                    bound++;
+                }
+                else
+                {
+                    method.NativeQualifiedSymbol = string.Empty;
+                    method.Bindable = false;
+                    method.NonBindableReason = reason;
+                    reasons[reason] = reasons.GetValueOrDefault(reason) + 1;
+                }
+            }
+
+            return new JoinReport(
+                manifest.Methods.Count, bound, manifest.Methods.Count - bound, reasons);
+        }
+
+        private static string Classify(
+            NativeBindingManifestMethod method,
+            Dictionary<(string, string), List<CallSiteSymbol>> byKey,
+            out string symbol)
+        {
+            symbol = string.Empty;
+
+            if (!byKey.TryGetValue((method.OwningClassName, method.ReflectedName), out var sites)
+                || sites.Count == 0)
+            {
+                return "UnresolvedNativeSymbol";
+            }
+
+            // More than one distinct &C::Method under a single script name is an
+            // overload set. Choosing either is a coin flip; bind neither.
+            var distinct = sites
+                .Select(s => s.NativeQualifiedSymbol)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+            if (sites.Count > 1 && distinct.Count > 1)
+            {
+                return "Overloaded";
+            }
+
+            if (sites.Any(s => s.ViaLambda))
+            {
+                return "ReflectedViaLambda";
+            }
+
+            if (string.IsNullOrEmpty(distinct[0]))
+            {
+                return "UnresolvedNativeSymbol";
+            }
+
+            // "void" is spelled with StorageClass Value but is not a value the
+            // emitter has to unpack, so it must not trip the Unknown check.
+            bool returnIsVoid = string.Equals(method.Return?.CppTypeName, "void", StringComparison.Ordinal);
+            if (!returnIsVoid && method.Return?.StorageClass == StorageUnknown)
+            {
+                return "UnsupportedArgStorage";
+            }
+
+            if (method.Arguments.Any(a => a.StorageClass == StorageUnknown))
+            {
+                return "UnsupportedArgStorage";
+            }
+
+            symbol = distinct[0];
+            return "None";
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test Code/Tools/BindingGenerator.Tests/BindingGenerator.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~NativeBindingJoinTests"`
+Expected: `Passed! - Failed: 0, Passed: 9`
+
+- [ ] **Step 5: Full suite**
+
+Run: `dotnet test Code/Tools/BindingGenerator.Tests/BindingGenerator.Tests.csproj -c Release --nologo`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Generation/NativeBindingJoin.cs Code/Tools/BindingGenerator.Tests/NativeBindingJoinTests.cs
+git commit -m "SP-1b-1: add the manifest/call-site join and conservative classifier
+
+Keyed on (className, reflectedName) - never reflectedName alone, which would
+cross-join Transform::GetLength onto AZ::Vector3::GetLength and produce a
+plausible-looking wrong pointer. Every ambiguity resolves to not-bindable,
+because an unbound method merely falls back to BehaviorMethod::Call while a
+mis-bound one calls a function pointer with a mismatched signature.
+
+Pure and I/O-free so the correctness-critical logic is provable without
+libclang or an engine."
+```
+
+---
+
+### Task 3: Restore and verify the libclang call-site parser
+
+**Files:**
+- Create: `Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Parsing/ReflectionCallSiteParser.cs`
+- Test: `Code/Tools/BindingGenerator.Tests/ReflectionCallSiteParserTests.cs`
+
+**Interfaces:**
+- Consumes: `CallSiteSymbol` (Task 2).
+- Produces: `ReflectionCallSiteResult ReflectionCallSiteParser.ParseFile(string path, IEnumerable<string> includePaths, IEnumerable<string> defines)`, exposing the recovered sites as `IReadOnlyList<CallSiteSymbol>`.
+
+> The rescued `ReflectionCallSiteParser.cs` is 756 lines and has **never compiled**. Restore it incrementally: get it building first, then make the fixture tests pass. Expect real defects.
+
+- [ ] **Step 1: Write the failing fixture tests**
+
+Create `Code/Tools/BindingGenerator.Tests/ReflectionCallSiteParserTests.cs`:
+
+```csharp
+//
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// For complete copyright and license terms please see the LICENSE at the root of this distribution.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+using System.IO;
+using System.Linq;
+using O3DESharp.BindingGenerator.Parsing;
+
+namespace O3DESharp.BindingGenerator.Tests;
+
+/// <summary>
+/// Recovering `&amp;C::Method` from a reflection .cpp is the only way to learn a
+/// native symbol - BehaviorContext type-erases it behind an AZStd::function, so
+/// no runtime pass can supply it. These use small real C++ fixtures rather than
+/// mocks, because what is being tested is precisely whether libclang sees what
+/// we think it sees.
+/// </summary>
+public class ReflectionCallSiteParserTests
+{
+    private static string WriteFixture(string dir, string name, string source)
+    {
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, name);
+        File.WriteAllText(path, source, System.Text.Encoding.UTF8);
+        return path;
+    }
+
+    [Fact]
+    public void RecoversPlainMemberFunctionPointer()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
+        {
+            var path = WriteFixture(dir, "Reflect.cpp", """
+            struct BehaviorContext {
+                template<class T> BehaviorContext* Class(const char*) { return this; }
+                template<class F> BehaviorContext* Method(const char*, F) { return this; }
+            };
+            struct Vector3 { float GetLength() const { return 0.0f; } };
+            void Reflect(BehaviorContext* c) {
+                c->Class<Vector3>("Vector3")->Method("GetLength", &Vector3::GetLength);
+            }
+            """);
+
+            var parser = new ReflectionCallSiteParser(verbose: false);
+            var result = parser.ParseFile(path, new[] { dir }, System.Array.Empty<string>());
+
+            var site = result.CallSites.Should().ContainSingle().Subject;
+            site.ReflectedName.Should().Be("GetLength");
+            site.NativeQualifiedSymbol.Should().Contain("Vector3::GetLength");
+            site.ViaLambda.Should().BeFalse();
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void FlagsLambdaReflectedMethodRatherThanGuessing()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
+        {
+            var path = WriteFixture(dir, "Reflect.cpp", """
+            struct BehaviorContext {
+                template<class T> BehaviorContext* Class(const char*) { return this; }
+                template<class F> BehaviorContext* Method(const char*, F) { return this; }
+            };
+            struct Vector3 { float GetLength() const { return 0.0f; } };
+            void Reflect(BehaviorContext* c) {
+                c->Class<Vector3>("Vector3")->Method("Weird", [](Vector3* v) { return 1.0f; });
+            }
+            """);
+
+            var parser = new ReflectionCallSiteParser(verbose: false);
+            var result = parser.ParseFile(path, new[] { dir }, System.Array.Empty<string>());
+
+            var site = result.CallSites.Should().ContainSingle().Subject;
+            site.ReflectedName.Should().Be("Weird");
+            site.ViaLambda.Should().BeTrue("a lambda has no &C::Method symbol to bind");
+            site.NativeQualifiedSymbol.Should().BeEmpty();
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void FileWithNoReflection_YieldsNoCallSites()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
+        {
+            var path = WriteFixture(dir, "Plain.cpp", "int main() { return 0; }\n");
+
+            var parser = new ReflectionCallSiteParser(verbose: false);
+            var result = parser.ParseFile(path, new[] { dir }, System.Array.Empty<string>());
+
+            result.CallSites.Should().BeEmpty();
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* best effort */ }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test Code/Tools/BindingGenerator.Tests/BindingGenerator.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~ReflectionCallSiteParserTests"`
+Expected: build failure — `ReflectionCallSiteParser` does not exist.
+
+- [ ] **Step 3: Restore the parser and get it compiling**
+
+Copy `Rescued/1b-native-trampoline/Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Parsing/ReflectionCallSiteParser.cs` into `Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Parsing/`.
+
+Then run `dotnet build Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/O3DESharp.BindingGenerator.csproj -c Release --nologo` and fix compile errors until clean. It has never been compiled, so errors are expected — likely candidates are ClangSharp API drift and references to types that were never written. **Do not stub out logic to make it compile**; if something references a genuinely missing type, report it rather than inventing behaviour.
+
+- [ ] **Step 4: Adapt its output to `CallSiteSymbol`**
+
+The parser's own `ReflectionCallSite` type may not match Task 2's `CallSiteSymbol`. Add a projection so `ReflectionCallSiteResult` exposes `IReadOnlyList<CallSiteSymbol> CallSites` — do not change `CallSiteSymbol`, which Task 2's tests pin.
+
+- [ ] **Step 5: Make the fixture tests pass**
+
+Run: `dotnet test Code/Tools/BindingGenerator.Tests/BindingGenerator.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~ReflectionCallSiteParserTests"`
+Expected: `Passed! - Failed: 0, Passed: 3`
+
+If the parser cannot recover the symbol from the minimal fixture, the fixture may be too unlike real O3DE reflection code (which uses `AZ::BehaviorContext` and macros). In that case make the fixture more realistic **rather than weakening the assertion** — and say so in the commit.
+
+- [ ] **Step 6: Full suite + commit**
+
+```bash
+dotnet test Code/Tools/BindingGenerator.Tests/BindingGenerator.Tests.csproj -c Release --nologo
+git add Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Parsing/ReflectionCallSiteParser.cs Code/Tools/BindingGenerator.Tests/ReflectionCallSiteParserTests.cs
+git commit -m "SP-1b-1: restore the libclang reflection call-site parser with fixture tests"
+```
+
+---
+
+### Task 4: CLI wiring — emit the joined manifest
+
+**Files:**
+- Modify: `Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Program.cs`
+- Test: `Code/Tools/BindingGenerator.Tests/NativeBindingCliTests.cs`
+
+**Interfaces:**
+- Consumes: `NativeBindingJoin.Apply` (Task 2), `ReflectionCallSiteParser` (Task 3).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Code/Tools/BindingGenerator.Tests/NativeBindingCliTests.cs`:
+
+```csharp
+//
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// For complete copyright and license terms please see the LICENSE at the root of this distribution.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+using System.IO;
+using System.Text.Json;
+using O3DESharp.BindingGenerator.Configuration;
+using O3DESharp.BindingGenerator.Generation;
+
+namespace O3DESharp.BindingGenerator.Tests;
+
+/// <summary>
+/// End-to-end over the offline half: a manifest emitted by the C++ pass plus a
+/// set of recovered call sites produces a joined manifest whose bound entries
+/// carry real symbols. The runtime half (registry, load-time validation,
+/// dispatch) is SP-1b-2 and not exercised here.
+/// </summary>
+public class NativeBindingCliTests
+{
+    [Fact]
+    public void JoinedManifest_IsWrittenWithSymbolsFilledIn()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var manifestPath = Path.Combine(dir, "native_bindings.json");
+            File.WriteAllText(manifestPath, """
+            {"methods":[{
+              "reflected_name":"GetLength","owning_class_name":"Vector3",
+              "owning_class_type_id":"{0}","owning_class_size_bytes":16,"owning_class_align_bytes":16,
+              "is_static":false,"is_const":true,"native_qualified_symbol":"",
+              "return":{"name":"","cpp_type_name":"float","type_id":"{1}","storage_class":"Value","size_bytes":4,"align_bytes":4},
+              "arguments":[],"bindable":false,"non_bindable_reason":"NoNativeSideCounterpart",
+              "binding_id":"Vector3::GetLength"}]}
+            """);
+
+            var doc = JsonSerializer.Deserialize<NativeBindingManifestDocument>(
+                File.ReadAllText(manifestPath))!;
+
+            var report = NativeBindingJoin.Apply(
+                doc,
+                new[] { new CallSiteSymbol("Vector3", "GetLength", "AZ::Vector3::GetLength", false) });
+
+            var outPath = Path.Combine(dir, "native_bindings.joined.json");
+            File.WriteAllText(outPath, JsonSerializer.Serialize(doc));
+
+            var reloaded = JsonSerializer.Deserialize<NativeBindingManifestDocument>(
+                File.ReadAllText(outPath))!;
+
+            report.Bound.Should().Be(1);
+            reloaded.Methods[0].Bindable.Should().BeTrue();
+            reloaded.Methods[0].NativeQualifiedSymbol.Should().Be("AZ::Vector3::GetLength");
+            reloaded.Methods[0].BindingId.Should().Be("Vector3::GetLength");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* best effort */ }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `dotnet test Code/Tools/BindingGenerator.Tests/BindingGenerator.Tests.csproj -c Release --nologo --filter "FullyQualifiedName~NativeBindingCliTests"`
+Expected: `Passed! - Failed: 0, Passed: 1` (it exercises Tasks 1-2 only; no new production code needed yet).
+
+- [ ] **Step 3: Add the CLI verb**
+
+Read `Program.cs` and follow its existing `System.CommandLine` idiom exactly (see how `generate` declares options). Add a `native-bindings` command taking:
+- `--manifest <path>` — the JSON emitted by the C++ runtime pass (required)
+- `--reflection-sources <glob-or-dir>` — reflection `.cpp` files to parse (required)
+- `--output <path>` — where to write the joined manifest (required)
+- `--verbose`
+
+It loads the manifest, parses call sites, calls `NativeBindingJoin.Apply`, writes the joined manifest, and prints the `JoinReport` — bound/unbound totals and a per-reason breakdown. **Print the report unconditionally, not behind `--verbose`:** a run that binds nothing is exactly the case a user most needs told about, and it is otherwise silent and indistinguishable from success.
+
+- [ ] **Step 4: Verify the CLI parses**
+
+Run: `dotnet run --project Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/O3DESharp.BindingGenerator.csproj -c Release -- native-bindings --help`
+Expected: the options above are listed, no parse error.
+
+- [ ] **Step 5: Full suite + commit**
+
+```bash
+dotnet test Code/Tools/BindingGenerator.Tests/BindingGenerator.Tests.csproj -c Release --nologo
+git add Code/Tools/BindingGenerator/O3DESharp.BindingGenerator/Program.cs Code/Tools/BindingGenerator.Tests/NativeBindingCliTests.cs
+git commit -m "SP-1b-1: add the native-bindings CLI verb that emits the joined manifest
+
+Reports bound/unbound counts and a per-reason breakdown unconditionally rather
+than behind --verbose: a run that binds nothing is the case most needing a
+diagnostic, and is otherwise silent and indistinguishable from success."
+```
+
+---
+
+## What is NOT in this plan
+
+**SP-1b-2 (the runtime half)** — `BindingRegistry`, trampoline emission into generated C++, load-time validation of every manifest entry against the live `BehaviorContext`, the dispatch hook with fallback, differential testing, and binding-coverage telemetry.
+
+It is deliberately deferred for two reasons: none of it is compile-verifiable in this environment, and the SP-1 spec gates it on SP-1a's thunk path being proven in a real engine build. Building it on an unverified foundation risks doing it twice.
+
+Trampoline *emission* sits in SP-1b-2 rather than here because the emitted code is C++ that must compile against the real `BehaviorArgument` API — writing an emitter with no way to compile its output would be generating unverifiable text.

--- a/docs/superpowers/specs/2026-07-15-sp1-marshaling-core-design.md
+++ b/docs/superpowers/specs/2026-07-15-sp1-marshaling-core-design.md
@@ -204,3 +204,53 @@ possible — it is not redundant with the offline half.
    never been compiled. The implementation plan must budget for the possibility that parts are
    rewritten rather than integrated; the rescue preserved *intent and analysis*, which is the durable
    value, not necessarily the exact lines.
+
+---
+
+## Appendix: learnings from Lumina Engine's scripting host
+
+Source: https://luminagameengine.com/internals/scripting-host/ (read 2026-07-20). Lumina hosts
+CoreCLR via hostfxr with collectible ALCs and name-resolved function pointers in both directions —
+architecturally the same choices as this gem, arrived at independently. Two of its safety
+mechanisms have no counterpart here and are worth adopting.
+
+### A1. Startup blittable-layout verification — ADOPT (SP-1b-2)
+
+Lumina's `CSharpLayoutChecks.cpp` verifies, at startup, that every struct crossing the boundary has
+matching size and field offsets on both sides, and fails with a named error on mismatch.
+
+This gem has the same exposure and no equivalent guard. `LifecycleId`'s integer values are pinned by
+a test (`LifecycleIdAbiTests`), but that is one enum checked by convention — nothing verifies the
+layout of argument structs passed through `[UnmanagedCallersOnly]` thunks. A C# `struct` field
+reordered or a type widened produces silent memory corruption, not a failure.
+
+Fold into SP-1b-2's load-time manifest validation (spec §7), which already walks every entry to
+compare arity and type ids against the live `BehaviorContext`. Adding size/offset to that comparison
+is close to free once the walk exists, and covers the same class of bug the manifest check exists to
+catch.
+
+### A2. Script generation counter — ADOPT (small, SP-1a follow-up)
+
+Lumina stamps a generation number (`GetScriptGeneration()`) that increments on every reload, and
+cached native pointers carry the generation they were resolved under. A pointer from a previous
+generation is *detected*, not dereferenced.
+
+`CoralNativeThunkHost` currently relies on every reload path remembering to call `InvalidateCache()`.
+One path added later that forgets leaves a dangling pointer into an unloaded ALC — and the failure
+is a crash in managed code with no obvious link to the missing call. A generation stamp makes the
+staleness detectable rather than depending on call-site discipline.
+
+Cheap: an integer bumped in `OnBeforeUserAssemblyReload`, stored alongside each cached thunk,
+compared on `Get`. Worth doing when SP-1a's C++ is next touched.
+
+### A3. Deliberately not adopted
+
+- **Roslyn in-process compilation.** Lumina compiles `.cs` in-process at runtime; this gem builds
+  through MSBuild/`dotnet`. Their model gives faster iteration, but in-process Roslyn is a large
+  dependency and is fundamentally incompatible with the AOT direction in
+  `2026-07-02-linux-aot-support-design.md`.
+- **Cooked-script manifest** (`scripts.manifest.json` + prebuilt assemblies). This is approximately
+  SP-6 (assemblies as assets) in the program design, which routes through the O3DE Asset Processor
+  instead — the engine-native equivalent.
+- **No AOT.** Lumina documents no AOT or NativeAOT story; it targets JIT CoreCLR. Nothing to learn
+  for the dual-mode AOT work, which is ahead of it.


### PR DESCRIPTION
Implements [the SP-1b-1 plan](docs/superpowers/plans/2026-07-15-sp1b1-native-binding-manifest-offline.md) — the offline half of AOT's static-dispatch foundation. **All four tasks; everything here is verified, no "not compile-verified" caveats.**

## Why an offline pass exists at all

`BehaviorContext` type-erases the native C++ function pointer inside an `AZStd::function`. Only the reflected *script* name survives, so a native symbol **can never** be recovered at runtime. It has to come from a libclang parse of each gem's reflection `.cpp`, recovering `&C::Method` from `->Method("name", &C::Method)` and joining it to the runtime-emitted manifest on `(className, reflectedName)`.

## What's here

- **Manifest schema** — the C++↔C# wire contract, with tests pinning every `[JsonPropertyName]`. Renaming one silently makes every method look unbindable.
- **The join + classifier** — pure, no I/O, no libclang, so the correctness-critical logic is provable without an engine.
- **The libclang call-site parser**, restored from the rescue branch.
- **`native-bindings` CLI verb** that emits the joined manifest and prints the bind report **unconditionally** — a run that binds nothing is exactly what a user needs told about.

## The find: a silent feature-killer in the rescued parser

The rescued code compiled clean on the first try — but it had a logic bug that would have shipped as *"the feature does nothing."*

`Walk()` used a pre-order push/pop scope stack, assuming `Class<T>("Name")` is an AST **ancestor** of the chained `->Method(...)`. It's the reverse: in `ctx->Class<T>("X")->Method(...)`, `Method` is the outer `CallExpr` and `Class<T>` nests *inside* its callee's base-object subtree. So the stack was always empty at extraction time and **every** recovered call site had `OwningClassName == ""` — the join key never matched, and every real gem would report `Bound: 0`. Silently.

Fixed with `ResolveChainScope`, which walks *down* the base-object chain to find the `Class<T>` root. The plan's own fixture tests never caught it because they don't assert `ClassName`.

## Verification

End-to-end through the real CLI against a libclang-parsed fixture, with deliberate mis-join bait — two classes sharing the reflected name `GetLength`, only one with a call site:

```
Vector3    bindable=True  sym='Vector3::GetLength' reason=None
Transform  bindable=False sym=''                   reason=UnresolvedNativeSymbol
```

`Transform` correctly refuses rather than inheriting `Vector3`'s pointer. That distinction is the whole safety argument: a missing binding falls back to `BehaviorMethod::Call` and costs speed, while a wrong one calls a function pointer with a mismatched signature.

Suite: **140 passed, 2 skipped** (baseline 123 + 17 new).

## Not in this PR

**SP-1b-2 (the runtime half)** — `BindingRegistry`, trampoline emission, load-time manifest validation, the dispatch hook, differential testing. Deferred deliberately: none of it is compile-verifiable here, and the SP-1 spec gates it on SP-1a's thunk path being proven in a real engine build.