### PR TITLE
Fix: wire NativeReflection dispatch to the implemented native calls

### DIFF
--- a/Assets/Scripts/O3DE.Core.Tests/NativeReflectionDispatchTests.cs
+++ b/Assets/Scripts/O3DE.Core.Tests/NativeReflectionDispatchTests.cs
@@ -1,0 +1,193 @@
+//
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// For complete copyright and license terms please see the LICENSE at the root of this distribution.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+using System;
+using System.Reflection;
+using System.Text.Json;
+using O3DE;
+using O3DE.Reflection;
+
+namespace O3DE.Core.Tests;
+
+/// <summary>
+/// Coverage for the NativeReflection dispatch methods that used to be
+/// unconditional NotImplementedException stubs: InvokeStaticMethod,
+/// InvokeInstanceMethod, InvokeGlobalMethod, GetProperty/SetProperty, and
+/// GetGlobalProperty/SetGlobalProperty. The native ReflectionInternalCalls
+/// function pointers are populated by Coral only inside a running host, so
+/// they are null here - these tests exercise only what's reachable without
+/// a host: the null/invalid-instance guards on the NativeObject overloads,
+/// and the SetProperty/SetGlobalProperty wire format.
+///
+/// Wire format, confirmed by reading GenericDispatcher::SetProperty /
+/// SetGlobalProperty in Code/Source/Scripting/Reflection/GenericDispatcher.cpp:
+/// both take valueJson as a BARE JSON value, not a single-element array.
+/// SetProperty parses it straight into the setter's one value parameter;
+/// SetGlobalProperty wraps it in "[%s]" itself before dispatching. Sending
+/// an already-wrapped array from C# (e.g. by reusing SerializeArguments)
+/// would silently send the wrong shape and fail to marshal on the native
+/// side - that's the regression these SerializeValue tests guard against.
+///
+/// Anything that reaches the unsafe `ReflectionInternalCalls.Reflection_*`
+/// function pointer call is NOT covered here: those fields are null outside
+/// a Coral host, so invoking them would access-violate the process rather
+/// than throw a catchable .NET exception. That surface needs an integration
+/// test running inside the real O3DE + Coral host, not a plain unit test.
+/// </summary>
+public class NativeReflectionDispatchTests
+{
+    private static NativeObject InvalidInstance(string typeName = "SomeClass")
+    {
+        // Handle 0 => NativeObject.IsValid is false.
+        return new NativeObject(typeName, 0);
+    }
+
+    private static object? InvokeSerializeValue(object value)
+    {
+        MethodInfo method = typeof(NativeReflection).GetMethod(
+            "SerializeValue",
+            BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                "NativeReflection.SerializeValue not found - has it been renamed?");
+
+        try
+        {
+            return method.Invoke(null, new object?[] { value });
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            throw ex.InnerException;
+        }
+    }
+
+    // --- InvokeInstanceMethod guards ---
+
+    [Fact]
+    public void InvokeInstanceMethod_NullInstance_ThrowsArgumentNullException()
+    {
+        Action act = () => NativeReflection.InvokeInstanceMethod(null!, "Foo");
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("instance");
+    }
+
+    [Fact]
+    public void InvokeInstanceMethod_InvalidInstance_ThrowsInvalidOperationException()
+    {
+        NativeObject instance = InvalidInstance();
+
+        Action act = () => NativeReflection.InvokeInstanceMethod(instance, "Foo");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Foo*")
+            .WithMessage("*invalid*");
+    }
+
+    // --- GetProperty<T> guards ---
+
+    [Fact]
+    public void GetProperty_NullInstance_ThrowsArgumentNullException()
+    {
+        Action act = () => NativeReflection.GetProperty<int>(null!, "Bar");
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("instance");
+    }
+
+    [Fact]
+    public void GetProperty_InvalidInstance_ThrowsInvalidOperationException()
+    {
+        NativeObject instance = InvalidInstance();
+
+        Action act = () => NativeReflection.GetProperty<int>(instance, "Bar");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Bar*")
+            .WithMessage("*invalid*");
+    }
+
+    // --- SetProperty guards ---
+
+    [Fact]
+    public void SetProperty_NullInstance_ThrowsArgumentNullException()
+    {
+        Action act = () => NativeReflection.SetProperty(null!, "Bar", 1);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("instance");
+    }
+
+    [Fact]
+    public void SetProperty_InvalidInstance_ThrowsInvalidOperationException()
+    {
+        NativeObject instance = InvalidInstance();
+
+        Action act = () => NativeReflection.SetProperty(instance, "Bar", 1);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Bar*")
+            .WithMessage("*invalid*");
+    }
+
+    // --- NativeObject convenience overloads route through the same guards ---
+
+    [Fact]
+    public void NativeObject_InvokeMethod_OnInvalidHandle_Throws()
+    {
+        NativeObject instance = InvalidInstance();
+
+        // NativeObject.InvokeMethod calls ThrowIfDisposed() first, which
+        // already rejects a Handle==0 instance before NativeReflection's
+        // own guard would ever run - confirms the two guard layers agree.
+        Action act = () => instance.InvokeMethod("Foo");
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    // --- SetProperty / SetGlobalProperty wire format: bare value, never an array ---
+
+    [Fact]
+    public void SerializeValue_Int_IsBareNumber_NotWrappedInArray()
+    {
+        object? result = InvokeSerializeValue(42);
+
+        result.Should().Be(JsonSerializer.Serialize(42));
+        result.Should().NotBe("[42]");
+    }
+
+    [Fact]
+    public void SerializeValue_String_IsBareJsonString_NotWrappedInArray()
+    {
+        object? result = InvokeSerializeValue("hello");
+
+        result.Should().Be(JsonSerializer.Serialize("hello"));
+        result.Should().NotBe("[\"hello\"]");
+    }
+
+    [Fact]
+    public void SerializeValue_Bool_IsBareJsonBool_NotWrappedInArray()
+    {
+        object? result = InvokeSerializeValue(true);
+
+        result.Should().Be(JsonSerializer.Serialize(true));
+        result.Should().NotBe("[true]");
+    }
+
+    [Fact]
+    public void SerializeValue_Vector3_IsSingleArray_NotDoublyWrapped()
+    {
+        object? result = InvokeSerializeValue(new Vector3(1.0f, 2.0f, 3.0f));
+
+        // Vector3 itself serializes to a 3-element array (the math-type wire
+        // shape). It must not be wrapped in a second, outer array - that's
+        // what would happen if SetProperty mistakenly used SerializeArguments
+        // (array-of-args) instead of SerializeValue (bare value).
+        string expected = JsonSerializer.Serialize(new float[] { 1.0f, 2.0f, 3.0f });
+        result.Should().Be(expected);
+        ((string)result!).Should().NotStartWith("[[");
+    }
+}

--- a/Assets/Scripts/O3DE.Core/Reflection/NativeReflection.cs
+++ b/Assets/Scripts/O3DE.Core/Reflection/NativeReflection.cs
@@ -224,15 +224,10 @@ namespace O3DE.Reflection
         /// <returns>The result as a dynamic object, or null for void methods</returns>
         public static object? InvokeStaticMethod(string className, string methodName, params object[] args)
         {
-            // The native dispatcher (GenericDispatcher::Reflection_InvokeStaticMethod)
-            // currently returns {"error":"Not fully implemented"} unconditionally.
-            // Throwing here makes the gap obvious instead of letting callers parse a
-            // success-shaped JSON envelope that never arrives.
-            throw new NotImplementedException(
-                "NativeReflection.InvokeStaticMethod is not yet implemented in the native " +
-                "dispatcher (see Code/Source/Scripting/Reflection/GenericDispatcher.cpp). " +
-                "Use direct API methods (e.g. Entity / Transform / Physics) for now, or " +
-                "extend the dispatcher to parse argsJson and call BehaviorMethod::Call.");
+            string argsJson = SerializeArguments(args);
+            string resultJson;
+            unsafe { resultJson = ReflectionInternalCalls.Reflection_InvokeStaticMethod(className, methodName, argsJson); }
+            return DeserializeResult(resultJson);
         }
 
         /// <summary>
@@ -244,10 +239,21 @@ namespace O3DE.Reflection
         /// <returns>The result as a dynamic object, or null for void methods</returns>
         public static object? InvokeInstanceMethod(NativeObject instance, string methodName, params object[] args)
         {
-            // Native dispatcher stub returns "Not fully implemented". See InvokeStaticMethod above.
-            throw new NotImplementedException(
-                "NativeReflection.InvokeInstanceMethod is not yet implemented in the native dispatcher. " +
-                "Use direct API methods for now.");
+            if (instance == null) { throw new ArgumentNullException(nameof(instance)); }
+            if (!instance.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot invoke '{methodName}' on an invalid NativeObject ({instance.TypeName}).");
+            }
+
+            string argsJson = SerializeArguments(args);
+            string resultJson;
+            unsafe
+            {
+                resultJson = ReflectionInternalCalls.Reflection_InvokeInstanceMethod(
+                    instance.TypeName, methodName, instance.Handle, argsJson);
+            }
+            return DeserializeResult(resultJson);
         }
 
         /// <summary>
@@ -258,10 +264,10 @@ namespace O3DE.Reflection
         /// <returns>The result as a dynamic object, or null for void methods</returns>
         public static object? InvokeGlobalMethod(string methodName, params object[] args)
         {
-            // Native dispatcher stub returns "Not fully implemented". See InvokeStaticMethod above.
-            throw new NotImplementedException(
-                "NativeReflection.InvokeGlobalMethod is not yet implemented in the native dispatcher. " +
-                "Use direct API methods for now.");
+            string argsJson = SerializeArguments(args);
+            string resultJson;
+            unsafe { resultJson = ReflectionInternalCalls.Reflection_InvokeGlobalMethod(methodName, argsJson); }
+            return DeserializeResult(resultJson);
         }
 
         #endregion
@@ -277,10 +283,21 @@ namespace O3DE.Reflection
         /// <returns>The property value</returns>
         public static T? GetProperty<T>(NativeObject instance, string propertyName)
         {
-            // Native dispatcher stub. See InvokeStaticMethod above.
-            throw new NotImplementedException(
-                "NativeReflection.GetProperty is not yet implemented in the native dispatcher. " +
-                "Use direct API methods for now.");
+            if (instance == null) { throw new ArgumentNullException(nameof(instance)); }
+            if (!instance.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot get property '{propertyName}' on an invalid NativeObject ({instance.TypeName}).");
+            }
+
+            string resultJson;
+            unsafe
+            {
+                resultJson = ReflectionInternalCalls.Reflection_GetProperty(
+                    instance.TypeName, propertyName, instance.Handle);
+            }
+            object? raw = DeserializeResult(resultJson);
+            return CoerceEBusResult<T>(raw, "GetProperty", instance.TypeName, propertyName, /*busId*/ null);
         }
 
         /// <summary>
@@ -291,10 +308,30 @@ namespace O3DE.Reflection
         /// <param name="value">The value to set</param>
         public static void SetProperty(NativeObject instance, string propertyName, object value)
         {
-            // Native dispatcher stub. See InvokeStaticMethod above.
-            throw new NotImplementedException(
-                "NativeReflection.SetProperty is not yet implemented in the native dispatcher. " +
-                "Use direct API methods for now.");
+            if (instance == null) { throw new ArgumentNullException(nameof(instance)); }
+            if (!instance.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot set property '{propertyName}' on an invalid NativeObject ({instance.TypeName}).");
+            }
+
+            // Reflection_SetProperty (GenericDispatcher::SetProperty) parses valueJson
+            // as a single bare JSON value - not a single-element array - and marshals it
+            // directly against the setter's one value parameter. Use SerializeValue
+            // (bare), not SerializeArguments (wraps in an array).
+            string valueJson = SerializeValue(value);
+            bool ok;
+            unsafe
+            {
+                ok = ReflectionInternalCalls.Reflection_SetProperty(
+                    instance.TypeName, propertyName, instance.Handle, valueJson);
+            }
+            if (!ok)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to set property '{instance.TypeName}.{propertyName}' " +
+                    "(native dispatcher rejected the call - see the native log for details).");
+            }
         }
 
         /// <summary>
@@ -305,9 +342,10 @@ namespace O3DE.Reflection
         /// <returns>The property value</returns>
         public static T? GetGlobalProperty<T>(string propertyName)
         {
-            // Native dispatcher stub. See InvokeStaticMethod above.
-            throw new NotImplementedException(
-                "NativeReflection.GetGlobalProperty is not yet implemented in the native dispatcher.");
+            string resultJson;
+            unsafe { resultJson = ReflectionInternalCalls.Reflection_GetGlobalProperty(propertyName); }
+            object? raw = DeserializeResult(resultJson);
+            return CoerceEBusResult<T>(raw, "GetGlobalProperty", "(global)", propertyName, /*busId*/ null);
         }
 
         /// <summary>
@@ -317,9 +355,19 @@ namespace O3DE.Reflection
         /// <param name="value">The value to set</param>
         public static void SetGlobalProperty(string propertyName, object value)
         {
-            // Native dispatcher stub. See InvokeStaticMethod above.
-            throw new NotImplementedException(
-                "NativeReflection.SetGlobalProperty is not yet implemented in the native dispatcher.");
+            // Reflection_SetGlobalProperty (GenericDispatcher::SetGlobalProperty) wraps
+            // valueJson into a single-element array itself before dispatching through
+            // the setter's BehaviorMethod - the value handed across the wire must be
+            // bare, same as SetProperty above.
+            string valueJson = SerializeValue(value);
+            bool ok;
+            unsafe { ok = ReflectionInternalCalls.Reflection_SetGlobalProperty(propertyName, valueJson); }
+            if (!ok)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to set global property '{propertyName}' " +
+                    "(native dispatcher rejected the call - see the native log for details).");
+            }
         }
 
         #endregion


### PR DESCRIPTION
The binding generator's **default** backend produced dead code. Seven `NativeReflection` methods threw `NotImplementedException` — but the native dispatcher they claimed was missing has been implemented since Phase 18.

## The bug

`InvokeStaticMethod`, `InvokeInstanceMethod`, `InvokeGlobalMethod`, `GetProperty<T>`, `SetProperty`, `GetGlobalProperty<T>`, `SetGlobalProperty` all threw, with comments asserting the native side *"returns `{"error":"Not fully implemented"}`"*.

That comment is stale. `GenericDispatcher.cpp:1273` says the opposite:

> The stubs that used to return "Not fully implemented" were pre-Phase-18 placeholders; **every reflection-backend generated wrapper for a class method / global function / property now routes through one of the implementations below.**

`ReflectionBindingGenerator.cs` — the **default** `--source reflection` backend — emits wrappers calling exactly these seven. So every generated class-method and property binding threw at runtime. Only the EBus bindings worked, because `BroadcastEBusEvent`/`SendEBusEvent` were already wired.

Everything needed was in place: C++ implementations, registered internal calls, and declared `delegate* unmanaged` fields. Only the C# bodies were missing.

## The wire format, verified against the C++ (not assumed)

The subtle part, and the reason this wasn't a copy-paste job:

| Call | `valueJson` shape | Why |
|---|---|---|
| `SetProperty` | **bare** (`42`) | C++ parses `valueDoc` and feeds it straight to `JsonValueToBehaviorParameter` for the setter's single parameter |
| `SetGlobalProperty` | **bare** (`42`) | C++ wraps it *itself* — `AZStd::string::format("[%s]", ...)` at `GenericDispatcher.cpp:2591`. Sending an array would **double-wrap** |
| `Invoke*` | array | matches `SerializeArguments`; for instance methods `this` is synthesized natively from the handle table (`skipFront=1`) |

Both setters therefore use the bare `SerializeValue` helper, not `SerializeArguments`. Getting this backwards would have been a silent data bug — a property write that parses as the wrong shape, with no error.

## Error surfacing

`Invoke*` and `GetProperty*` return the standard JSON envelope and reuse `DeserializeResult`, matching the existing `BroadcastEBusEvent` convention.

The setters return a bare `Bool32` with **no** envelope — the C++ side only `AZ_Warning`s. Returning silently on `false` would mean a requested property write vanishing with no signal, so both now throw `InvalidOperationException`.

`GetProperty<T>` / `GetGlobalProperty<T>` reuse the existing `CoerceEBusResult<T>` for the lossy JSON wire (a C++ `float` arrives as `Double`), rather than adding a second coercion path.

## Testing

**72 passed** (61 baseline + 11 new): null-instance and invalid-handle guards, plus wire-format regression tests asserting `SerializeValue` produces bare JSON for int/string/bool/Vector3 and never array-wraps.

Deliberately **not** tested: the actual native dispatch calls. The `delegate* unmanaged` fields are null outside a Coral host, so invoking them would access-violate rather than throw catchably. That needs a host-backed integration test, not a fake one.

## Note

This touches the `NativeReflection.Invoke*` / `Get/SetProperty` surface reserved for the 1.3 BehaviorContext refactor — but only its **wiring**, not its dispatch internals. The refactor's design space is unchanged; this just stops the default backend shipping dead code in the meantime.