### PR TITLE
Fix: classify Vector2/Vector4/Color; assert marshal parity in both directions

### DIFF
--- a/Code/Source/Scripting/Reflection/BehaviorContextReflector.cpp
+++ b/Code/Source/Scripting/Reflection/BehaviorContextReflector.cpp
@@ -11,7 +11,10 @@
 #include <AzCore/Console/ILogger.h>
 #include <AzCore/std/containers/unordered_set.h>
 #include <AzCore/std/sort.h>
+#include <AzCore/Math/Color.h>
+#include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
+#include <AzCore/Math/Vector4.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Component/EntityId.h>
@@ -599,13 +602,25 @@ namespace O3DESharp
         {
             marshalType = ReflectedParameter::MarshalType::String;
         }
+        else if (typeId == azrtti_typeid<AZ::Vector2>())
+        {
+            marshalType = ReflectedParameter::MarshalType::Vector2;
+        }
         else if (typeId == azrtti_typeid<AZ::Vector3>())
         {
             marshalType = ReflectedParameter::MarshalType::Vector3;
         }
+        else if (typeId == azrtti_typeid<AZ::Vector4>())
+        {
+            marshalType = ReflectedParameter::MarshalType::Vector4;
+        }
         else if (typeId == azrtti_typeid<AZ::Quaternion>())
         {
             marshalType = ReflectedParameter::MarshalType::Quaternion;
+        }
+        else if (typeId == azrtti_typeid<AZ::Color>())
+        {
+            marshalType = ReflectedParameter::MarshalType::Color;
         }
         else if (typeId == azrtti_typeid<AZ::Transform>())
         {

--- a/Code/Source/Scripting/Reflection/BehaviorContextReflector.h
+++ b/Code/Source/Scripting/Reflection/BehaviorContextReflector.h
@@ -48,8 +48,11 @@ namespace O3DESharp
             Float,
             Double,
             String,
+            Vector2,
             Vector3,
+            Vector4,
             Quaternion,
+            Color,
             Transform,
             EntityId,
             Object,     // Complex object requiring special handling

--- a/Code/Source/Scripting/Reflection/ReflectionDataExporter.cpp
+++ b/Code/Source/Scripting/Reflection/ReflectionDataExporter.cpp
@@ -632,10 +632,16 @@ namespace O3DESharp
             return "Double";
         case ReflectedParameter::MarshalType::String:
             return "String";
+        case ReflectedParameter::MarshalType::Vector2:
+            return "Vector2";
         case ReflectedParameter::MarshalType::Vector3:
             return "Vector3";
+        case ReflectedParameter::MarshalType::Vector4:
+            return "Vector4";
         case ReflectedParameter::MarshalType::Quaternion:
             return "Quaternion";
+        case ReflectedParameter::MarshalType::Color:
+            return "Color";
         case ReflectedParameter::MarshalType::Transform:
             return "Transform";
         case ReflectedParameter::MarshalType::EntityId:

--- a/Editor/Tests/test_marshal_type_parity.py
+++ b/Editor/Tests/test_marshal_type_parity.py
@@ -83,6 +83,26 @@ def test_every_cpp_marshal_tag_is_mapped_in_csharp():
 
 
 @pytest.mark.unit
+def test_every_csharp_case_is_emitted_by_cpp():
+    """The reverse direction: no C# case without a C++ tag that produces it.
+
+    A C# case for a tag the exporter never emits is dead code that reads as
+    working support. Vector2/Vector4/Color were exactly that until the C++
+    MarshalType enum, classifier, and stringifier gained them - the generator
+    looked ready for those types while every one of them arrived as `Object`
+    and mapped to `object`.
+    """
+    cpp = _cpp_marshal_tags()
+    csharp = _csharp_mapped_tags()
+    unreachable = sorted(csharp - cpp)
+    assert not unreachable, (
+        f"MapMarshalToCSharp has case(s) {unreachable} that the C++ exporter never emits. "
+        "Either the C++ MarshalType enum/classifier/stringifier is missing them (so those "
+        "types silently marshal as Object), or the C# cases are dead and should go."
+    )
+
+
+@pytest.mark.unit
 def test_tags_are_pascal_case_on_both_sides():
     # The mapper's switch is ordinal/case-sensitive. A casing drift on either
     # side is the same silent-`object` failure as a missing case.


### PR DESCRIPTION
Closes the gap found in #20 and makes the parity guard bidirectional.

## The gap

`MapMarshalToCSharp` had cases for `Vector2`, `Vector4`, and `Color`. The C++ `MarshalType` enum had **no such values** — so parameters of those types fell through to `Object`, and every generated binding took them as `object`.

The C# side read as though it supported them. Nothing did.

## The fix

`BehaviorContextMarshaling` already round-trips all three (verified before touching anything), so this was purely a classification gap:

- three enum values in `BehaviorContextReflector.h`
- three `azrtti_typeid` checks in the classifier
- three `MarshalTypeToString` cases in the exporter
- **the `Color.h` / `Vector2.h` / `Vector4.h` includes** — only `Vector3.h` was there, so the new `azrtti_typeid` calls wouldn't have compiled

## Bidirectional parity

With the gap closed, the test from #20 now asserts the reverse direction too: **no C# case may exist without a C++ tag that produces it.**

Both sets are now exactly **22 and identical**. Either side drifting fails the build — a missing C# case (silent `object` degradation) or a dead C# case (support that reads as real but isn't).

## Deliberately not included

`Aabb`, `Crc32`, `Uuid`, `Matrix3x3`, `Matrix4x4`. The marshaling table handles them, but neither the enum nor the C# mapper does — adding them means touching both sides plus real thought about their C# representation. That's its own change, not a drive-by.

## Testing

Python suite: **107 passed**. The parity test now covers both directions.

**NOT COMPILE-VERIFIED** — no O3DE engine SDK here. The C++ is three enum values, three `else if` branches, three `case` labels, and three includes, all matching surrounding patterns exactly, but it needs a real build.